### PR TITLE
Remove duplicate idempotency_key index

### DIFF
--- a/outie-jooq-provider/src/main/resources/db/migration/V20251113.0000__remove_duplicate_idempotency_key_index.sql
+++ b/outie-jooq-provider/src/main/resources/db/migration/V20251113.0000__remove_duplicate_idempotency_key_index.sql
@@ -1,0 +1,1 @@
+DROP INDEX idempotency_key_idx ON withdrawal_responses;


### PR DESCRIPTION
Remove duplicate idempotency_key index

Drop the idempotency_key_idx index from withdrawal_responses table
as it was a duplicate index. This migration cleans up the schema by
removing the redundant index definition.