### PR TITLE
Add withdrawalWithToken test helper

### DIFF
--- a/outie/src/test/kotlin/xyz/block/bittycity/outie/controllers/EligibilityControllerTest.kt
+++ b/outie/src/test/kotlin/xyz/block/bittycity/outie/controllers/EligibilityControllerTest.kt
@@ -31,7 +31,7 @@ class EligibilityControllerTest : BittyCityTestCase() {
 
     subject.execute(withdrawal, emptyList(), Operation.EXECUTE).getOrThrow()
 
-    withdrawalStore.getWithdrawalByToken(withdrawal.id).getOrThrow() should {
+    withdrawalWithToken(withdrawal.id) should {
       it.state shouldBe Failed
       it.failureReason shouldBe CUSTOMER_IS_INELIGIBLE
     }
@@ -49,7 +49,7 @@ class EligibilityControllerTest : BittyCityTestCase() {
 
     subject.execute(withdrawal, emptyList(), Operation.EXECUTE).getOrThrow()
 
-    withdrawalStore.getWithdrawalByToken(withdrawal.id).getOrThrow()
+    withdrawalWithToken(withdrawal.id)
       .state shouldBe WaitingForPendingConfirmationStatus
   }
 }

--- a/outie/src/test/kotlin/xyz/block/bittycity/outie/controllers/OnChainControllerTest.kt
+++ b/outie/src/test/kotlin/xyz/block/bittycity/outie/controllers/OnChainControllerTest.kt
@@ -53,7 +53,7 @@ class OnChainControllerTest : BittyCityTestCase() {
       .getOrThrow()
       .shouldBeInstanceOf<ProcessingState.UserInteractions<Withdrawal, RequirementId>>()
 
-    withdrawalStore.getWithdrawalByToken(withdrawal.id).getOrThrow()
+    withdrawalWithToken(withdrawal.id)
       .shouldBeWithdrawal(withdrawal.copy(state = WaitingForPendingConfirmationStatus))
 
     // Process outbox
@@ -62,7 +62,7 @@ class OnChainControllerTest : BittyCityTestCase() {
     onChainService.getSubmittedWithdrawal(withdrawal.id).shouldNotBeNull()
       .destinationAddress shouldBe withdrawal.targetWalletAddress
 
-    withdrawalStore.getWithdrawalByToken(withdrawal.id).getOrThrow()
+    withdrawalWithToken(withdrawal.id)
       .shouldNotBeNull()
       .state shouldBe WaitingForPendingConfirmationStatus
   }
@@ -176,7 +176,7 @@ class OnChainControllerTest : BittyCityTestCase() {
       .shouldBeFailure<LimitWouldBeExceeded>()
 
     // Verify the withdrawal was stored with the correct state
-    withdrawalStore.getWithdrawalByToken(withdrawal.id).getOrThrow() should {
+    withdrawalWithToken(withdrawal.id) should {
       it.state shouldBe Failed
       it.failureReason shouldBe FailureReason.LIMITED
     }
@@ -196,7 +196,7 @@ class OnChainControllerTest : BittyCityTestCase() {
       subject.processInputs(withdrawal, listOf(resumeResult), Operation.EXECUTE)
         .shouldBeSuccess()
 
-      withdrawalStore.getWithdrawalByToken(withdrawal.id).getOrThrow() should {
+      withdrawalWithToken(withdrawal.id) should {
         it.state shouldBe Failed
         it.failureReason shouldBe FailureReason.FAILED_ON_CHAIN
       }
@@ -215,7 +215,7 @@ class OnChainControllerTest : BittyCityTestCase() {
     subject.processInputs(withdrawal, listOf(resumeResult), Operation.EXECUTE)
       .shouldBeSuccess()
 
-    withdrawalStore.getWithdrawalByToken(withdrawal.id).getOrThrow() should {
+    withdrawalWithToken(withdrawal.id) should {
       it.state shouldBe Failed
       it.failureReason shouldBe FailureReason.FAILED_ON_CHAIN
     }
@@ -233,7 +233,7 @@ class OnChainControllerTest : BittyCityTestCase() {
     onChainWithdrawalDomainApi.resume(withdrawal.id, resumeResult)
       .shouldBeFailure<IllegalArgumentException>()
 
-    withdrawalStore.getWithdrawalByToken(withdrawal.id).getOrThrow()
+    withdrawalWithToken(withdrawal.id)
       .state shouldBe WaitingForPendingConfirmationStatus
   }
 
@@ -249,7 +249,7 @@ class OnChainControllerTest : BittyCityTestCase() {
     onChainWithdrawalDomainApi.execute(withdrawal.id, emptyList())
       .shouldBeFailure<Exception>()
 
-    withdrawalStore.getWithdrawalByToken(withdrawal.id).getOrThrow() should {
+    withdrawalWithToken(withdrawal.id) should {
       it.state shouldBe Failed
       it.failureReason shouldBe FailureReason.UNKNOWN
     }
@@ -268,7 +268,7 @@ class OnChainControllerTest : BittyCityTestCase() {
       .getOrThrow()
       .shouldBeInstanceOf<ProcessingState.Complete<Withdrawal, RequirementId>>()
 
-    withdrawalStore.getWithdrawalByToken(withdrawal.id).getOrThrow()
+    withdrawalWithToken(withdrawal.id)
       .shouldBeWithdrawal(withdrawal.copy(state = ConfirmedComplete))
   }
 }

--- a/outie/src/test/kotlin/xyz/block/bittycity/outie/controllers/RiskControllerTest.kt
+++ b/outie/src/test/kotlin/xyz/block/bittycity/outie/controllers/RiskControllerTest.kt
@@ -38,7 +38,7 @@ class RiskControllerTest : BittyCityTestCase() {
       Operation.EXECUTE
     ).shouldBeFailure<RiskBlocked>()
 
-    withdrawalStore.getWithdrawalByToken(withdrawal.id).getOrThrow() should {
+    withdrawalWithToken(withdrawal.id) should {
       it.state shouldBe Failed
       it.failureReason shouldBe FailureReason.RISK_BLOCKED
     }
@@ -55,7 +55,7 @@ class RiskControllerTest : BittyCityTestCase() {
 
     subject.execute(withdrawal, emptyList(), Operation.EXECUTE).getOrThrow()
 
-    withdrawalStore.getWithdrawalByToken(withdrawal.id).getOrThrow()
+    withdrawalWithToken(withdrawal.id)
       .state shouldBe CollectingScamWarningDecision
   }
 
@@ -70,7 +70,7 @@ class RiskControllerTest : BittyCityTestCase() {
 
     subject.execute(withdrawal, emptyList(), Operation.EXECUTE).getOrThrow()
 
-    withdrawalStore.getWithdrawalByToken(withdrawal.id).getOrThrow()
+    withdrawalWithToken(withdrawal.id)
       .state shouldBe WaitingForPendingConfirmationStatus
   }
 }

--- a/outie/src/test/kotlin/xyz/block/bittycity/outie/controllers/SanctionsControllerTest.kt
+++ b/outie/src/test/kotlin/xyz/block/bittycity/outie/controllers/SanctionsControllerTest.kt
@@ -60,7 +60,7 @@ class SanctionsControllerTest : BittyCityTestCase() {
     this@SanctionsControllerTest.subject.processInputs(withdrawal, emptyList(), Operation.EXECUTE)
       .shouldBeFailure<RiskBlocked>()
 
-    withdrawalStore.getWithdrawalByToken(withdrawal.id).getOrThrow() should {
+    withdrawalWithToken(withdrawal.id) should {
       it.state shouldBe Failed
       it.failureReason shouldBe FailureReason.SANCTIONS_FAILED
     }

--- a/outie/src/test/kotlin/xyz/block/bittycity/outie/controllers/SanctionsInfoCollectionControllerTest.kt
+++ b/outie/src/test/kotlin/xyz/block/bittycity/outie/controllers/SanctionsInfoCollectionControllerTest.kt
@@ -57,7 +57,7 @@ class SanctionsInfoCollectionControllerTest : BittyCityTestCase() {
     complete.hurdles.size shouldBe 1
     complete.hurdles[0] shouldBe WithdrawalNotification.WithdrawalSanctionsHeld
 
-    withdrawalStore.getWithdrawalByToken(withdrawal.id).getOrThrow()
+    withdrawalWithToken(withdrawal.id)
       .state shouldBe WaitingForSanctionsHeldDecision
   }
 
@@ -78,7 +78,7 @@ class SanctionsInfoCollectionControllerTest : BittyCityTestCase() {
     complete.hurdles.size shouldBe 1
     complete.hurdles[0] shouldBe WithdrawalNotification.WithdrawalSanctionsHeld
 
-    withdrawalStore.getWithdrawalByToken(withdrawal.id).getOrThrow()
+    withdrawalWithToken(withdrawal.id)
       .state shouldBe WaitingForSanctionsHeldDecision
   }
 
@@ -94,7 +94,7 @@ class SanctionsInfoCollectionControllerTest : BittyCityTestCase() {
       Operation.EXECUTE
     ).shouldBeFailure<DomainApiError.InvalidRequirementResult>()
 
-    withdrawalStore.getWithdrawalByToken(withdrawal.id).getOrThrow()
+    withdrawalWithToken(withdrawal.id)
       .state shouldBe CollectingSanctionsInfo
   }
 }

--- a/outie/src/test/kotlin/xyz/block/bittycity/outie/controllers/ScamWarningControllerTest.kt
+++ b/outie/src/test/kotlin/xyz/block/bittycity/outie/controllers/ScamWarningControllerTest.kt
@@ -38,7 +38,7 @@ class ScamWarningControllerTest : BittyCityTestCase() {
     updated.state shouldBe Failed
     updated.failureReason shouldBe FailureReason.CUSTOMER_CANCELLED
 
-    withdrawalStore.getWithdrawalByToken(withdrawal.id).getOrThrow().shouldBeWithdrawal(updated)
+    withdrawalWithToken(withdrawal.id).shouldBeWithdrawal(updated)
   }
 
   @Test
@@ -63,8 +63,7 @@ class ScamWarningControllerTest : BittyCityTestCase() {
     subject
       .updateValue(withdrawal, WithdrawalHurdleResponse.ScamWarningHurdleResponse(FINISHED_OK))
       .shouldBeFailure(UnsupportedHurdleResultCode(withdrawal.customerId.id, FINISHED_OK))
-    withdrawalStore.getWithdrawalByToken(withdrawal.id)
-      .getOrThrow().version shouldBe withdrawal.version
+    withdrawalWithToken(withdrawal.id).version shouldBe withdrawal.version
   }
 
   @Test
@@ -77,8 +76,7 @@ class ScamWarningControllerTest : BittyCityTestCase() {
         WithdrawalHurdleResponse.SpeedHurdleResponse(ResultCode.CLEARED, WithdrawalSpeed.PRIORITY)
       )
       .shouldBeFailure<IllegalArgumentException>()
-    withdrawalStore.getWithdrawalByToken(withdrawal.id)
-      .getOrThrow().version shouldBe withdrawal.version
+    withdrawalWithToken(withdrawal.id).version shouldBe withdrawal.version
   }
 
   @Test

--- a/outie/src/test/kotlin/xyz/block/bittycity/outie/jobs/FailStuckWithdrawalsJobTest.kt
+++ b/outie/src/test/kotlin/xyz/block/bittycity/outie/jobs/FailStuckWithdrawalsJobTest.kt
@@ -42,12 +42,12 @@ class FailStuckWithdrawalsJobTest : BittyCityTestCase() {
     )
     failStuckWithdrawalsJob.execute(false)
 
-    withdrawalStore.getWithdrawalByToken(stuckWithdrawal.id).getOrThrow() should {
+    withdrawalWithToken(stuckWithdrawal.id) should {
       it.state shouldBe Failed
       it.failureReason shouldBe FailureReason.CUSTOMER_ABANDONED
     }
 
-    withdrawalStore.getWithdrawalByToken(stillNotStuckWithdrawal.id).getOrThrow()
+    withdrawalWithToken(stillNotStuckWithdrawal.id)
       .state shouldBe CollectingSelfAttestation
   }
 
@@ -73,10 +73,10 @@ class FailStuckWithdrawalsJobTest : BittyCityTestCase() {
     )
     failStuckWithdrawalsJob.execute(logOnly = true)
 
-    withdrawalStore.getWithdrawalByToken(stuckWithdrawal.id).getOrThrow()
+    withdrawalWithToken(stuckWithdrawal.id)
       .state shouldBe CollectingInfo
 
-    withdrawalStore.getWithdrawalByToken(stillNotStuckWithdrawal.id).getOrThrow()
+    withdrawalWithToken(stillNotStuckWithdrawal.id)
       .state shouldBe CollectingSelfAttestation
   }
 }

--- a/outie/src/test/kotlin/xyz/block/bittycity/outie/jobs/RetryStuckWithdrawalsJobTest.kt
+++ b/outie/src/test/kotlin/xyz/block/bittycity/outie/jobs/RetryStuckWithdrawalsJobTest.kt
@@ -43,10 +43,10 @@ class RetryStuckWithdrawalsJobTest : BittyCityTestCase() {
 
     retryStuckWithdrawalsJob.execute(false)
 
-    withdrawalStore.getWithdrawalByToken(stuckWithdrawal.id).getOrThrow()
+    withdrawalWithToken(stuckWithdrawal.id)
       .state shouldBe WaitingForPendingConfirmationStatus
 
-    withdrawalStore.getWithdrawalByToken(stillNotStuckWithdrawal.id).getOrThrow()
+    withdrawalWithToken(stillNotStuckWithdrawal.id)
       .state shouldBe CheckingEligibility
   }
 
@@ -72,10 +72,10 @@ class RetryStuckWithdrawalsJobTest : BittyCityTestCase() {
     )
     retryStuckWithdrawalsJob.execute(logOnly = true)
 
-    withdrawalStore.getWithdrawalByToken(stuckWithdrawal.id).getOrThrow()
+    withdrawalWithToken(stuckWithdrawal.id)
       .state shouldBe CheckingEligibility
 
-    withdrawalStore.getWithdrawalByToken(stillNotStuckWithdrawal.id).getOrThrow()
+    withdrawalWithToken(stillNotStuckWithdrawal.id)
       .state shouldBe CheckingEligibility
   }
 }

--- a/outie/src/test/kotlin/xyz/block/bittycity/outie/store/WithdrawalStoreTest.kt
+++ b/outie/src/test/kotlin/xyz/block/bittycity/outie/store/WithdrawalStoreTest.kt
@@ -17,12 +17,15 @@ import io.kotest.matchers.result.shouldBeSuccess
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.arbitrary.next
+import jakarta.inject.Inject
 import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
 class WithdrawalStoreTest : BittyCityTestCase() {
+
+  @Inject lateinit var withdrawalStore: WithdrawalStore
 
   @Test
   fun `create new withdrawal success`() = runTest {

--- a/outie/src/test/kotlin/xyz/block/bittycity/outie/testing/TestApp.kt
+++ b/outie/src/test/kotlin/xyz/block/bittycity/outie/testing/TestApp.kt
@@ -54,7 +54,7 @@ class TestApp @Inject constructor(
   @Inject lateinit var sanctionsClient: FakeSanctionsClient
   @Inject lateinit var travelRuleClient: FakeTravelRuleClient
 
-  @Inject lateinit var withdrawalStore: WithdrawalStore
+  @Inject private lateinit var withdrawalStore: WithdrawalStore
   @Inject lateinit var withdrawalTransactor: Transactor<WithdrawalOperations>
   @Inject lateinit var onChainWithdrawalDomainApi: OnChainWithdrawalDomainApi
 
@@ -166,4 +166,7 @@ class TestApp @Inject constructor(
   fun processWithdrawalEvents() {
     withdrawalEventBatchProcessor.processBatches().getOrThrow()
   }
+
+  fun withdrawalWithToken(token: WithdrawalToken): Withdrawal =
+    withdrawalStore.getWithdrawalByToken(token).getOrThrow()
 }


### PR DESCRIPTION
Add withdrawalWithToken test helper

Added TestApp.withdrawalWithToken() helper function to simplify fetching withdrawals in tests. Replaced all uses of withdrawalStore.getWithdrawalByToken(...).getOrThrow() with withdrawalWithToken(...) across 8 test files (25 occurrences total).

Tightens the visibility of withdrawalStore in TestApp