### PR TITLE
Bump Kotest and kotlinBinaryCompatibilityPlugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
   alias(libs.plugins.versionsGradlePlugin)
   alias(libs.plugins.versionCatalogUpdateGradlePlugin)
   alias(libs.plugins.kotlinBinaryCompatibilityPlugin) apply false
-  id("com.vanniktech.maven.publish") version "0.34.0" apply false
+  id("com.vanniktech.maven.publish") version "0.35.0" apply false
 }
 
 subprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,28 +6,28 @@ flyway = "11.15.0"
 guice = "7.0.0"
 hikari = "7.0.2"
 jodaMoney = "2.0.2"
-jooq = "3.19.15"
+jooq = "3.19.17"
 junit4 = "4.13.2"
-junitPlatformRunner = "1.10.2"
+junitPlatformRunner = "1.10.5"
 kfsm = "0.11.2"
-kotest = "5.8.0"
+kotest = "5.9.1"
 kotestArrow = "2.0.0"
 # @pin
 kotlin = "2.0.21"
-kotlinBinaryCompatibilityPlugin = "0.13.2"
+kotlinBinaryCompatibilityPlugin = "0.16.3"
 kotlinLogging = "7.0.13"
 mavenPublish = "0.33.0"
-mockk = "1.13.10"
+mockk = "1.13.14"
 moshi = "1.15.2"
 mysql = "3.5.6"
-mysqlConnector = "9.1.0"
-quiver = "1.0.0"
+mysqlConnector = "9.5.0"
+quiver = "1.0.2"
 reflections = "0.10.2"
 resilience4j = "2.3.0"
 slf4j = "2.0.17"
 testContainersMySql = "1.21.3"
-versionCatalogUpdateGradlePlugin = "0.8.3"
-versionsGradlePlugin = "0.50.0"
+versionCatalogUpdateGradlePlugin = "0.8.5"
+versionsGradlePlugin = "0.53.0"
 
 [libraries]
 arrowCore = { module = "io.arrow-kt:arrow-core", version.ref = "arrow" }
@@ -76,7 +76,7 @@ kotest = [
 ]
 
 [plugins]
-dokka = "org.jetbrains.dokka:2.0.0"
+dokka = "org.jetbrains.dokka:2.1.0"
 kotlinBinaryCompatibilityPlugin = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinBinaryCompatibilityPlugin" }
 kotlinGradlePlugin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 mavenPublish = { id = "com.vanniktech.maven.publish.base", version.ref = "mavenPublish" }


### PR DESCRIPTION
Bump Kotest and kotlinBinaryCompatibilityPlugin

Upgrade kotest from 5.8.0 to 5.9.1 and kotlinBinaryCompatibilityPlugin
from 0.13.2 to 0.16.3 to get latest bug fixes and features.