### PR TITLE
Mark business rule failures as InfoOnly

### DIFF
--- a/outie/src/main/kotlin/xyz/block/bittycity/outie/client/EligibilityClient.kt
+++ b/outie/src/main/kotlin/xyz/block/bittycity/outie/client/EligibilityClient.kt
@@ -1,5 +1,7 @@
 package xyz.block.bittycity.outie.client
 
+import xyz.block.domainapi.InfoOnly
+
 /**
  * Interface for a service that determines if a user is eligible to use a Bitcoin product.
  */
@@ -36,4 +38,4 @@ sealed class Eligibility {
 
 
 
-class IneligibleCustomer(val violations: List<String>) : Exception()
+class IneligibleCustomer(val violations: List<String>) : Exception(), InfoOnly

--- a/outie/src/main/kotlin/xyz/block/bittycity/outie/client/LedgerClient.kt
+++ b/outie/src/main/kotlin/xyz/block/bittycity/outie/client/LedgerClient.kt
@@ -5,6 +5,7 @@ import xyz.block.bittycity.common.models.Bitcoins
 import xyz.block.bittycity.common.models.CustomerId
 import xyz.block.bittycity.common.models.LedgerTransactionId
 import xyz.block.bittycity.outie.models.Withdrawal
+import xyz.block.domainapi.InfoOnly
 
 /**
  * Interface for a service that handles ledgering operations for on-chain withdrawals.
@@ -88,6 +89,6 @@ sealed class LedgerError: Exception()
 data object IdempotencyKeyReused: LedgerError()
 data object TransactionAlreadyCompleted: LedgerError()
 data object TransactionDoesNotExist : LedgerError()
-data object InsufficientFunds: LedgerError()
+data object InsufficientFunds: LedgerError(), InfoOnly
 data class InternalServerError(override val message: String): LedgerError()
 data class InvalidRequest(override val message: String): LedgerError()

--- a/outie/src/main/kotlin/xyz/block/bittycity/outie/controllers/OnChainController.kt
+++ b/outie/src/main/kotlin/xyz/block/bittycity/outie/controllers/OnChainController.kt
@@ -24,6 +24,7 @@ import xyz.block.bittycity.outie.store.WithdrawalStore
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.inject.Inject
+import xyz.block.domainapi.InfoOnly
 import xyz.block.domainapi.Input
 import xyz.block.domainapi.ProcessingState
 import xyz.block.domainapi.util.Operation
@@ -183,4 +184,4 @@ class OnChainController @Inject constructor(
 data class LimitWouldBeExceeded(val violations: List<LimitViolation>) :
   Exception(
     "Withdrawal limits would be exceeded: $violations"
-  )
+  ), InfoOnly


### PR DESCRIPTION
### Problem
Several expected business exceptions were being logged at ERROR level when they should be logged at INFO level:
- IneligibleCustomer - Customer doesn't meet eligibility requirements
- InsufficientFunds - Ledger operation failed due to insufficient funds
- LimitWouldBeExceeded - Withdrawal would exceed limits

These are expected business rule violations, not system errors. Other similar exceptions (ValidationError subclasses, RiskBlocked) already implement InfoOnly to log at INFO level.

### Solution
Made these three exceptions implement the InfoOnly marker interface to align with existing patterns and reduce error noise in logs.

### Changes
- IneligibleCustomer now implements InfoOnly
- InsufficientFunds now implements InfoOnly
- LimitWouldBeExceeded now implements InfoOnly

This ensures consistent logging behavior for all expected business logic violations across the codebase.