### PR TITLE
Publish innie artifact to maven

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,7 +58,7 @@ dokka {
 tasks.register("publishToMavenCentral") {
   group = "publishing"
   dependsOn(
-//    ":innie:publishToMavenCentral",
+    ":innie:publishToMavenCentral",
     ":outie:publishToMavenCentral",
     ":outie-jooq-provider:publishToMavenCentral"
   )


### PR DESCRIPTION
### Background
Right now the `innie` artifact is not available in maven central. Despite `innie` not being fully implemented, having it available will allow us to introduce the library to the monorepo and pull it in.

### Changes

- Being publishing innie to mavenCentral