### PR TITLE
Add idempotency support for resume and fix bugs

### DIFF
--- a/common/src/main/kotlin/xyz/block/bittycity/common/idempotency/IdempotentResumeInputs.kt
+++ b/common/src/main/kotlin/xyz/block/bittycity/common/idempotency/IdempotentResumeInputs.kt
@@ -1,0 +1,16 @@
+package xyz.block.bittycity.common.idempotency
+
+import xyz.block.domainapi.Input
+
+/**
+ * Inputs for a resume operation that need to be hashed for idempotency.
+ *
+ * @param ID The type of the request identifier (e.g., WithdrawalToken, DepositToken).
+ * @param REQ The type of the requirement identifier used in Domain API (e.g., RequirementId).
+ * @param id The request identifier.
+ * @param resumeResult The resume result from the client.
+ */
+data class IdempotentResumeInputs<ID, REQ>(
+  val id: ID,
+  val resumeResult: Input.ResumeResult<REQ>
+)

--- a/innie/build.gradle.kts
+++ b/innie/build.gradle.kts
@@ -30,6 +30,8 @@ dependencies {
   implementation(libs.kfsm)
   implementation(libs.kotlinLogging)
   implementation(libs.kotlinReflect)
+  implementation(libs.moshi)
+  implementation(libs.moshiKotlin)
   implementation(libs.quiverLib)
   implementation(libs.slf4jApi)
   implementation(libs.slf4jNop)

--- a/innie/src/main/kotlin/xyz/block/bittycity/innie/InnieModule.kt
+++ b/innie/src/main/kotlin/xyz/block/bittycity/innie/InnieModule.kt
@@ -2,6 +2,7 @@ package xyz.block.bittycity.innie
 
 import com.google.inject.AbstractModule
 import xyz.block.bittycity.common.models.Bitcoins
+import xyz.block.bittycity.innie.controllers.DomainControllerModule
 import xyz.block.bittycity.innie.fsm.StateMachineModule
 
 open class InnieModule  : AbstractModule() {
@@ -9,6 +10,7 @@ open class InnieModule  : AbstractModule() {
   override fun configure() {
     installValidationModule()
     install(StateMachineModule)
+    install(DomainControllerModule)
     Bitcoins.currency
   }
 

--- a/innie/src/main/kotlin/xyz/block/bittycity/innie/controllers/DomainControllerModule.kt
+++ b/innie/src/main/kotlin/xyz/block/bittycity/innie/controllers/DomainControllerModule.kt
@@ -1,0 +1,46 @@
+package xyz.block.bittycity.innie.controllers
+
+import com.google.inject.AbstractModule
+import com.google.inject.Provides
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types.newParameterizedType
+import jakarta.inject.Singleton
+import xyz.block.bittycity.common.idempotency.IdempotentInputs
+import xyz.block.bittycity.common.idempotency.IdempotentResumeInputs
+import xyz.block.bittycity.common.store.Transactor
+import xyz.block.bittycity.innie.models.DepositToken
+import xyz.block.bittycity.innie.models.RequirementId
+import xyz.block.bittycity.innie.store.ResponseOperations
+
+object DomainControllerModule : AbstractModule() {
+
+  @Provides
+  @Singleton
+  fun provideIdempotencyHandler(
+    moshi: Moshi,
+    transactor: Transactor<ResponseOperations>
+  ): IdempotencyHandler {
+    return IdempotencyHandler(
+      moshi = moshi,
+      transactor = transactor,
+      inputsAdapter = { m ->
+        m.adapter(
+          newParameterizedType(
+            IdempotentInputs::class.java,
+            DepositToken::class.java,
+            RequirementId::class.java
+          )
+        )
+      },
+      resumeInputsAdapter = { m ->
+        m.adapter(
+          newParameterizedType(
+            IdempotentResumeInputs::class.java,
+            DepositToken::class.java,
+            RequirementId::class.java
+          )
+        )
+      }
+    )
+  }
+}

--- a/innie/src/main/kotlin/xyz/block/bittycity/innie/json/DepositMoshi.kt
+++ b/innie/src/main/kotlin/xyz/block/bittycity/innie/json/DepositMoshi.kt
@@ -1,0 +1,88 @@
+package xyz.block.bittycity.innie.json
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.ToJson
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import xyz.block.bittycity.common.models.Bitcoins
+import xyz.block.bittycity.common.models.CustomerId
+import xyz.block.bittycity.innie.models.DepositToken
+import java.time.Instant
+
+/**
+ * Provides a configured Moshi instance for deposit-related JSON serialization/deserialization.
+ */
+object DepositMoshi {
+
+  fun create(): Moshi = Moshi.Builder()
+    .add(InstantAdapter())
+    .add(BitcoinsAdapter())
+    .add(CustomerIdAdapter())
+    .add(DepositTokenAdapter())
+    .add(RequirementIdJsonAdapter)
+    .addLast(KotlinJsonAdapterFactory())
+    .build()
+
+  class InstantAdapter {
+    @ToJson
+    fun toJson(instant: Instant): Long = instant.toEpochMilli()
+
+    @FromJson
+    fun fromJson(epochMilli: Long): Instant = Instant.ofEpochMilli(epochMilli)
+  }
+
+  class BitcoinsAdapter {
+    @ToJson
+    fun toJson(bitcoins: Bitcoins): Long = bitcoins.units
+
+    @FromJson
+    fun fromJson(value: Long): Bitcoins = Bitcoins(value)
+  }
+
+  class CustomerIdAdapter {
+    @ToJson
+    fun toJson(customerId: CustomerId): String = customerId.id
+
+    @FromJson
+    fun fromJson(id: String): CustomerId = CustomerId(id)
+  }
+
+  class DepositTokenAdapter {
+    @ToJson
+    fun toJson(token: DepositToken): String = token.toString()
+
+    @FromJson
+    fun fromJson(token: String): DepositToken = DepositToken.parse(token).getOrThrow()
+  }
+
+  object RequirementIdJsonAdapter : JsonAdapter<xyz.block.bittycity.innie.models.RequirementId>() {
+    @ToJson
+    override fun toJson(writer: JsonWriter, value: xyz.block.bittycity.innie.models.RequirementId?) {
+      if (value == null) {
+        writer.nullValue()
+        return
+      }
+      writer.beginObject()
+      writer.name("name").value(value.name)
+      writer.name("requiresSecureEndpoint").value(value.requiresSecureEndpoint)
+      writer.endObject()
+    }
+
+    @FromJson
+    override fun fromJson(reader: JsonReader): xyz.block.bittycity.innie.models.RequirementId? {
+      var name: String? = null
+      reader.beginObject()
+      while (reader.hasNext()) {
+        when (reader.nextName()) {
+          "name" -> name = reader.nextString()
+          else -> reader.skipValue()
+        }
+      }
+      reader.endObject()
+      return name?.let { xyz.block.bittycity.innie.models.RequirementId.valueOf(it) }
+    }
+  }
+}

--- a/innie/src/main/kotlin/xyz/block/bittycity/innie/models/Inputs.kt
+++ b/innie/src/main/kotlin/xyz/block/bittycity/innie/models/Inputs.kt
@@ -1,0 +1,8 @@
+package xyz.block.bittycity.innie.models
+
+import xyz.block.bittycity.common.idempotency.IdempotentInputs
+
+/**
+ * Deposit-specific type alias for idempotent inputs.
+ */
+typealias Inputs = IdempotentInputs<DepositToken, RequirementId>

--- a/innie/src/main/kotlin/xyz/block/bittycity/innie/store/ResponseOperations.kt
+++ b/innie/src/main/kotlin/xyz/block/bittycity/innie/store/ResponseOperations.kt
@@ -1,0 +1,10 @@
+package xyz.block.bittycity.innie.store
+
+import xyz.block.bittycity.common.idempotency.IdempotencyOperations
+import xyz.block.bittycity.innie.models.DepositToken
+import xyz.block.bittycity.innie.models.RequirementId
+
+/**
+ * Deposit-specific type alias for response operations.
+ */
+typealias ResponseOperations = IdempotencyOperations<DepositToken, RequirementId>

--- a/innie/src/test/kotlin/xyz/block/bittycity/innie/testing/FakeResponseOperations.kt
+++ b/innie/src/test/kotlin/xyz/block/bittycity/innie/testing/FakeResponseOperations.kt
@@ -1,0 +1,57 @@
+package xyz.block.bittycity.innie.testing
+
+import arrow.core.raise.result
+import xyz.block.bittycity.common.idempotency.AlreadyProcessingException
+import xyz.block.bittycity.common.idempotency.IdempotentResponse
+import xyz.block.bittycity.common.idempotency.ResponseNotPresent
+import xyz.block.bittycity.common.idempotency.ResponseVersionMismatch
+import xyz.block.bittycity.innie.models.DepositToken
+import xyz.block.bittycity.innie.models.RequirementId
+import xyz.block.bittycity.innie.store.ResponseOperations
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * In-memory fake implementation of ResponseOperations for testing.
+ */
+class FakeResponseOperations : ResponseOperations {
+  private val responses = ConcurrentHashMap<Pair<String, DepositToken>, IdempotentResponse<DepositToken, RequirementId>>()
+
+  override fun findResponse(
+    idempotencyKey: String,
+    requestId: DepositToken
+  ): Result<IdempotentResponse<DepositToken, RequirementId>?> = result {
+    responses[idempotencyKey to requestId]
+  }
+
+  override fun insertResponse(
+    response: IdempotentResponse<DepositToken, RequirementId>
+  ): Result<IdempotentResponse<DepositToken, RequirementId>> = result {
+    val key = response.idempotencyKey to response.requestId
+    val existing = responses.putIfAbsent(key, response.copy(version = 1))
+    if (existing != null) {
+      raise(AlreadyProcessingException(RuntimeException("Response already exists")))
+    }
+    response.copy(version = 1)
+  }
+
+  override fun updateResponse(
+    idempotencyKey: String,
+    response: IdempotentResponse<DepositToken, RequirementId>
+  ): Result<IdempotentResponse<DepositToken, RequirementId>> = result {
+    val key = idempotencyKey to response.requestId
+    val existing = responses[key] ?: raise(ResponseNotPresent(idempotencyKey))
+
+    // Optimistic locking check
+    if (existing.version != response.version) {
+      raise(ResponseVersionMismatch(response.version, response.requestId.toString()))
+    }
+
+    val updated = response.copy(version = response.version + 1)
+    responses[key] = updated
+    updated
+  }
+
+  fun clear() {
+    responses.clear()
+  }
+}

--- a/innie/src/test/kotlin/xyz/block/bittycity/innie/testing/FakeResponseTransactor.kt
+++ b/innie/src/test/kotlin/xyz/block/bittycity/innie/testing/FakeResponseTransactor.kt
@@ -1,0 +1,20 @@
+package xyz.block.bittycity.innie.testing
+
+import xyz.block.bittycity.common.store.Transactor
+import xyz.block.bittycity.innie.store.ResponseOperations
+
+/**
+ * Simple fake transactor that delegates directly to the operations without actual transaction management.
+ */
+class FakeResponseTransactor(
+  private val operations: ResponseOperations
+) : Transactor<ResponseOperations> {
+
+  override fun <T> transact(comment: String, block: ResponseOperations.() -> Result<T>): Result<T> {
+    return operations.block()
+  }
+
+  override fun <T> transactReadOnly(comment: String, block: ResponseOperations.() -> Result<T>): Result<T> {
+    return operations.block()
+  }
+}

--- a/innie/src/test/kotlin/xyz/block/bittycity/innie/testing/TestModule.kt
+++ b/innie/src/test/kotlin/xyz/block/bittycity/innie/testing/TestModule.kt
@@ -1,12 +1,38 @@
 package xyz.block.bittycity.innie.testing
 
 import com.google.inject.AbstractModule
+import com.google.inject.Provides
 import com.google.inject.Scopes
+import com.google.inject.TypeLiteral
+import com.squareup.moshi.Moshi
+import jakarta.inject.Singleton
+import xyz.block.bittycity.common.idempotency.IdempotencyOperations
+import xyz.block.bittycity.common.store.Transactor
+import xyz.block.bittycity.innie.json.DepositMoshi
+import xyz.block.bittycity.innie.models.DepositToken
+import xyz.block.bittycity.innie.models.RequirementId
+import xyz.block.bittycity.innie.store.ResponseOperations
 
 class TestModule : AbstractModule() {
 
   override fun configure() {
     install(BittyCityTestModule)
+
+    // Bind the concrete generic type that Guice expects
+    bind(object : TypeLiteral<IdempotencyOperations<DepositToken, RequirementId>>() {})
+      .to(FakeResponseOperations::class.java)
+      .`in`(Scopes.SINGLETON)
+    bind(FakeResponseOperations::class.java).`in`(Scopes.SINGLETON)
+
+    bind(Moshi::class.java).toInstance(DepositMoshi.create())
+  }
+
+  @Provides
+  @Singleton
+  fun provideResponseTransactor(
+    operations: IdempotencyOperations<DepositToken, RequirementId>
+  ): Transactor<ResponseOperations> {
+    return FakeResponseTransactor(operations)
   }
 
   private inline fun <reified A, reified B : A> bindSingletonFake() {

--- a/outie-jooq-provider/src/main/kotlin/xyz/block/bittycity/outie/jooq/JooqResponseOperations.kt
+++ b/outie-jooq-provider/src/main/kotlin/xyz/block/bittycity/outie/jooq/JooqResponseOperations.kt
@@ -105,6 +105,7 @@ class JooqResponseOperations(
             )
             .where(WITHDRAWAL_RESPONSES.IDEMPOTENCY_KEY.eq(idempotencyKey))
             .and(WITHDRAWAL_RESPONSES.WITHDRAWAL_TOKEN.eq(response.requestId.toString()))
+            .and(WITHDRAWAL_RESPONSES.VERSION.eq(ULong.valueOf(response.version)))
 
         val updatedRows = updateStep.execute()
         val refreshed = findResponse(idempotencyKey, response.requestId).bind()

--- a/outie-jooq-provider/src/main/resources/db/migration/V20251119.0000__fix_idempotency_key_composite_unique_constraint.sql
+++ b/outie-jooq-provider/src/main/resources/db/migration/V20251119.0000__fix_idempotency_key_composite_unique_constraint.sql
@@ -1,0 +1,8 @@
+-- Drop the existing unique constraint on idempotency_key alone
+-- and replace it with a composite unique constraint on (idempotency_key, withdrawal_token)
+-- This ensures that the same idempotency_key can be used for different withdrawal tokens,
+-- which properly scopes collision risk to individual withdrawals (UUIDs).
+
+ALTER TABLE withdrawal_responses
+DROP INDEX idempotency_key,
+ADD UNIQUE INDEX idempotency_composite_idx (idempotency_key, withdrawal_token);

--- a/outie/src/main/kotlin/xyz/block/bittycity/outie/controllers/DomainControllerModule.kt
+++ b/outie/src/main/kotlin/xyz/block/bittycity/outie/controllers/DomainControllerModule.kt
@@ -5,6 +5,7 @@ import com.google.inject.Provides
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types.newParameterizedType
 import xyz.block.bittycity.common.idempotency.IdempotentInputs
+import xyz.block.bittycity.common.idempotency.IdempotentResumeInputs
 import xyz.block.bittycity.common.store.Transactor
 import xyz.block.bittycity.outie.models.CheckingEligibility
 import xyz.block.bittycity.outie.models.CheckingRisk
@@ -96,6 +97,15 @@ object DomainControllerModule : AbstractModule() {
         m.adapter(
           newParameterizedType(
             IdempotentInputs::class.java,
+            WithdrawalToken::class.java,
+            RequirementId::class.java
+          )
+        )
+      },
+      resumeInputsAdapter = { m ->
+        m.adapter(
+          newParameterizedType(
+            IdempotentResumeInputs::class.java,
             WithdrawalToken::class.java,
             RequirementId::class.java
           )

--- a/outie/src/main/kotlin/xyz/block/bittycity/outie/controllers/InfoCollectionController.kt
+++ b/outie/src/main/kotlin/xyz/block/bittycity/outie/controllers/InfoCollectionController.kt
@@ -241,7 +241,7 @@ class AmountHandler @Inject constructor(
   private val limitClient: LimitClient,
   private val validationService: ValidationService,
   private val withdrawalStore: WithdrawalStore,
-  @Named("withdrawal.amounts.minimum") private val minAmount: Long
+  @param:Named("withdrawal.amounts.minimum") private val minAmount: Long
 ) {
   fun getHurdle(value: Withdrawal, currentBalance: Bitcoins) = result {
     val bitcoinAccount = getBitcoinAccount(value.customerId, value.sourceBalanceToken).bind()
@@ -347,8 +347,8 @@ class SpeedHandler @Inject constructor(
   private val currencyDisplayPreferenceClient: CurrencyDisplayPreferenceClient,
   private val feeQuoteClient: FeeQuoteClient,
   private val withdrawalStore: WithdrawalStore,
-  @Named("withdrawal.amounts.minimum") val minimum: Long,
-  @Named("withdrawal.amounts.free_tier_minimum") val amountFreeTierMin: Long,
+  @param:Named("withdrawal.amounts.minimum") val minimum: Long,
+  @param:Named("withdrawal.amounts.free_tier_minimum") val amountFreeTierMin: Long,
 ) {
   fun getHurdles(value: Withdrawal, currentBalance: Bitcoins) = result {
     val exchangeRate =

--- a/outie/src/main/kotlin/xyz/block/bittycity/outie/jobs/FailStuckWithdrawalsJob.kt
+++ b/outie/src/main/kotlin/xyz/block/bittycity/outie/jobs/FailStuckWithdrawalsJob.kt
@@ -19,7 +19,7 @@ class FailStuckWithdrawalsJob @Inject constructor(
   override val stateMachine: StateMachine<WithdrawalToken, Withdrawal, WithdrawalState>,
   private val withdrawalStore: WithdrawalStore,
   private val metricsClient: MetricsClient,
-  @Named("withdrawal.stuck_after_minutes") private val stuckAfterMinutes: Long,
+  @param:Named("withdrawal.stuck_after_minutes") private val stuckAfterMinutes: Long,
 ) : WithdrawalTransitioner {
 
   override val logger: KLogger = KotlinLogging.logger {}

--- a/outie/src/main/kotlin/xyz/block/bittycity/outie/jobs/RetryStuckWithdrawalsJob.kt
+++ b/outie/src/main/kotlin/xyz/block/bittycity/outie/jobs/RetryStuckWithdrawalsJob.kt
@@ -19,7 +19,7 @@ class RetryStuckWithdrawalsJob @Inject constructor(
   override val stateMachine: StateMachine<WithdrawalToken, Withdrawal, WithdrawalState>,
   private val withdrawalStore: WithdrawalStore,
   private val domainController: WithdrawalDomainController,
-  @Named("withdrawal.retryable_stuck_after_minutes") private val stuckAfterMinutes: Long,
+  @param:Named("withdrawal.retryable_stuck_after_minutes") private val stuckAfterMinutes: Long,
 ) : WithdrawalTransitioner {
 
   override val logger: KLogger = KotlinLogging.logger {}

--- a/outie/src/main/kotlin/xyz/block/bittycity/outie/validation/ValidationService.kt
+++ b/outie/src/main/kotlin/xyz/block/bittycity/outie/validation/ValidationService.kt
@@ -13,7 +13,7 @@ import xyz.block.domainapi.InfoOnly
 @Singleton
 class ValidationService @Inject constructor(
   private val ledgerClient: LedgerClient,
-  @Named("withdrawal.amounts.minimum") val minAmount: Long
+  @param:Named("withdrawal.amounts.minimum") val minAmount: Long
 ) {
   fun validateAmount(
     customerId: CustomerId,

--- a/outie/src/test/kotlin/xyz/block/bittycity/outie/testing/TestApp.kt
+++ b/outie/src/test/kotlin/xyz/block/bittycity/outie/testing/TestApp.kt
@@ -33,9 +33,9 @@ import xyz.block.domainapi.ExecuteResponse
 import xyz.block.domainapi.Input
 
 class TestApp @Inject constructor(
-  @Named(DATASOURCE) val dslContext: DSLContext,
-  @Named("withdrawal.amounts.minimum") val minAmount: Long,
-  @Named("withdrawal.amounts.free_tier_minimum") val minAmountFreeTier: Long,
+  @param:Named(DATASOURCE) val dslContext: DSLContext,
+  @param:Named("withdrawal.amounts.minimum") val minAmount: Long,
+  @param:Named("withdrawal.amounts.free_tier_minimum") val minAmountFreeTier: Long,
 ) {
 
   @Inject lateinit var data: TestRunData


### PR DESCRIPTION
Adds support for idempotency handling in the resume operation. Also fixes two bugs in the idempotency handling implementation:
- The index in the database schema was defined incorrectly - it should be a composite index with `idempotency_key` and `withdrawal_token`.
- The version should be included when updating the response to provide optimistic locking.