### PR TITLE
Add missing gradle.properties file in new common module

### DIFF
--- a/common/gradle.properties
+++ b/common/gradle.properties
@@ -1,0 +1,4 @@
+POM_ARTIFACT_ID=common
+POM_NAME=Bitty City - Common
+POM_DESCRIPTION=Module with common functionality used in the Bitcoin experience products
+POM_PACKAGING=jar


### PR DESCRIPTION
Publishing to Maven Central is failing because of this.