### PR TITLE
Fix initialization timing issue in WithdrawalState.aliasedStatesMap

### DIFF
--- a/outie/src/main/kotlin/xyz/block/bittycity/outie/models/WithdrawalState.kt
+++ b/outie/src/main/kotlin/xyz/block/bittycity/outie/models/WithdrawalState.kt
@@ -42,12 +42,14 @@ sealed class WithdrawalState(
     }
 
     // For backwards compatibility when parsing, here's a list of deprecated states
-    private val aliasedStatesMap: Map<String, WithdrawalState> = mapOf(
-      "COLLECTING_SPEED_SELECTION" to CollectingInfo,
-      "COLLECTING_USER_CONFIRMATION" to CollectingInfo,
-      "PERFORMING_STEP_UP_AUTHENTICATION" to CollectingInfo,
-      "RESERVING_FUNDS" to CollectingInfo,
-    )
+    private val aliasedStatesMap: Map<String, WithdrawalState> by lazy {
+      mapOf(
+        "COLLECTING_SPEED_SELECTION" to CollectingInfo,
+        "COLLECTING_USER_CONFIRMATION" to CollectingInfo,
+        "PERFORMING_STEP_UP_AUTHENTICATION" to CollectingInfo,
+        "RESERVING_FUNDS" to CollectingInfo,
+      )
+    }
 
     fun byName(name: String): Result<WithdrawalState> = result {
       allStatesMap[name]


### PR DESCRIPTION
## Summary

Fixes a production issue where `RESERVING_FUNDS` alias lookup was failing with `IllegalStateException: Unknown withdrawal state: RESERVING_FUNDS` despite the mapping being present in v0.0.3.

## Root Cause

The `aliasedStatesMap` was eagerly initialized in the companion object:

```kotlin
private val aliasedStatesMap: Map<String, WithdrawalState> = mapOf(
  "RESERVING_FUNDS" to CollectingInfo,
  // ...
)
```

In complex classloading scenarios (multiple modules, Guice DI, parallel class loading), this eager initialization could occur before all sealed subclasses are fully loaded, causing the map entries to be null or initialization to fail silently.

## The Fix

Make `aliasedStatesMap` lazy, matching the pattern already used for `allStatesMap`:

```kotlin
private val aliasedStatesMap: Map<String, WithdrawalState> by lazy {
  mapOf(
    "RESERVING_FUNDS" to CollectingInfo,
    // ...
  )
}
```

This defers map creation until `byName()` is called, at which point all state objects are guaranteed to be available.

## Evidence

- Production logs show clean ASCII bytes for "RESERVING_FUNDS" (no encoding issues)
- Error only occurs in complex repo with multiple bitty-city modules
- Local tests pass (simpler classloading environment)
- The mapping exists in source but lookup fails at runtime

## Testing

All existing tests pass, including the test specifically for `RESERVING_FUNDS` alias:

```bash
gradle :outie:test --tests "xyz.block.bittycity.outie.models.WithdrawalStateTest"
```