### PR TITLE
[SQBTC-1302] Add deposit reversal info collection contoller

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -22,7 +22,9 @@ mavenPublishing {
 
 dependencies {
     implementation(libs.arrowCore)
+    implementation(libs.bitcoinj)
     implementation(libs.domainApi)
+    implementation(libs.guice)
     implementation(libs.jodaMoney)
     implementation(libs.kfsm)
     implementation(libs.moshi)

--- a/common/src/main/kotlin/xyz/block/bittycity/common/utils/WalletAddressParser.kt
+++ b/common/src/main/kotlin/xyz/block/bittycity/common/utils/WalletAddressParser.kt
@@ -1,4 +1,4 @@
-package xyz.block.bittycity.outie.validation
+package xyz.block.bittycity.common.utils
 
 import app.cash.quiver.extensions.catch
 import jakarta.inject.Inject

--- a/innie/src/main/kotlin/xyz/block/bittycity/innie/client/MetricsClient.kt
+++ b/innie/src/main/kotlin/xyz/block/bittycity/innie/client/MetricsClient.kt
@@ -2,6 +2,7 @@ package xyz.block.bittycity.innie.client
 
 import xyz.block.bittycity.innie.models.Deposit
 import xyz.block.bittycity.innie.models.DepositFailureReason
+import xyz.block.bittycity.innie.models.DepositReversalFailureReason
 import xyz.block.bittycity.innie.models.DepositState
 
 interface MetricsClient {
@@ -24,6 +25,13 @@ interface MetricsClient {
    */
   fun failureReason(
     reason: DepositFailureReason
+  ): Result<Unit>
+
+  /**
+   * Emits a metric used to count the number of different failure reasons for deposit reversals.
+   */
+  fun reversalFailureReason(
+    reason: DepositReversalFailureReason
   ): Result<Unit>
 
   /**

--- a/innie/src/main/kotlin/xyz/block/bittycity/innie/controllers/DepositInfoCollectionController.kt
+++ b/innie/src/main/kotlin/xyz/block/bittycity/innie/controllers/DepositInfoCollectionController.kt
@@ -1,0 +1,36 @@
+package xyz.block.bittycity.innie.controllers
+
+import app.cash.kfsm.StateMachine
+import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
+import xyz.block.bittycity.innie.client.MetricsClient
+import xyz.block.bittycity.innie.models.Deposit
+import xyz.block.bittycity.innie.models.DepositReversalFailureReason
+import xyz.block.bittycity.innie.models.DepositState
+import xyz.block.bittycity.innie.models.DepositToken
+import xyz.block.bittycity.innie.models.RequirementId
+import xyz.block.bittycity.innie.store.DepositStore
+import xyz.block.domainapi.util.HurdleGroup
+import xyz.block.domainapi.util.InfoCollectionController
+
+abstract class DepositInfoCollectionController(
+  override val pendingCollectionState: DepositState,
+  override val stateMachine: StateMachine<DepositToken, Deposit, DepositState>,
+  val depositStore: DepositStore,
+  val metricsClient: MetricsClient,
+): DepositController(
+  stateMachine,
+  metricsClient,
+  depositStore
+), InfoCollectionController<DepositToken, DepositState, Deposit, RequirementId>,
+  DepositStateHelpers {
+  override val logger: KLogger = KotlinLogging.logger {}
+
+  override val hurdleGroups = mapOf<String, HurdleGroup<RequirementId>>()
+
+  override fun onCancel(value: Deposit): Result<Deposit> =
+    value.failReversal(DepositReversalFailureReason.CUSTOMER_CANCELLED, metricsClient)
+
+  override fun requiresSecureEndpoint(requirement: RequirementId): Boolean =
+    requirement.requiresSecureEndpoint
+}

--- a/innie/src/main/kotlin/xyz/block/bittycity/innie/controllers/DepositReversalController.kt
+++ b/innie/src/main/kotlin/xyz/block/bittycity/innie/controllers/DepositReversalController.kt
@@ -1,0 +1,44 @@
+package xyz.block.bittycity.innie.controllers
+
+import app.cash.kfsm.StateMachine
+import arrow.core.raise.result
+import jakarta.inject.Inject
+import xyz.block.bittycity.innie.client.MetricsClient
+import xyz.block.bittycity.innie.models.CollectingInfo
+import xyz.block.bittycity.innie.models.Deposit
+import xyz.block.bittycity.innie.models.DepositState
+import xyz.block.bittycity.innie.models.DepositToken
+import xyz.block.bittycity.innie.models.RequirementId
+import xyz.block.bittycity.innie.models.WaitingForReversal
+import xyz.block.bittycity.innie.store.DepositStore
+import xyz.block.domainapi.Input
+import xyz.block.domainapi.ProcessingState
+import xyz.block.domainapi.util.Operation
+
+class DepositReversalController @Inject constructor(
+  stateMachine: StateMachine<DepositToken, Deposit, DepositState>,
+  depositStore: DepositStore,
+  private val metricsClient: MetricsClient,
+) : DepositController(stateMachine, metricsClient, depositStore) {
+  override fun processInputs(
+    value: Deposit,
+    inputs: List<Input<RequirementId>>,
+    operation: Operation,
+    hurdleGroupId: String?
+  ): Result<ProcessingState<Deposit, RequirementId>> = result {
+    when (value.state) {
+      WaitingForReversal -> value.transitionTo(CollectingInfo, metricsClient).bind()
+      else -> raise(mismatchedState(value))
+    }.asProcessingState()
+  }
+
+  override fun handleFailure(
+    failure: Throwable,
+    value: Deposit
+  ): Result<Deposit> = result {
+    logger.warn(failure) {
+      "An unexpected error occurred starting a deposit reversal."
+    }
+    raise(failure)
+  }
+}

--- a/innie/src/main/kotlin/xyz/block/bittycity/innie/controllers/DepositReversalRiskController.kt
+++ b/innie/src/main/kotlin/xyz/block/bittycity/innie/controllers/DepositReversalRiskController.kt
@@ -1,0 +1,36 @@
+package xyz.block.bittycity.innie.controllers
+
+import app.cash.kfsm.StateMachine
+import arrow.core.raise.result
+import jakarta.inject.Inject
+import xyz.block.bittycity.innie.client.MetricsClient
+import xyz.block.bittycity.innie.models.Deposit
+import xyz.block.bittycity.innie.models.DepositState
+import xyz.block.bittycity.innie.models.DepositToken
+import xyz.block.bittycity.innie.models.RequirementId
+import xyz.block.bittycity.innie.models.WaitingForReversalPendingConfirmationStatus
+import xyz.block.bittycity.innie.store.DepositStore
+import xyz.block.domainapi.Input
+import xyz.block.domainapi.ProcessingState
+import xyz.block.domainapi.util.Operation
+
+class DepositReversalRiskController @Inject constructor(
+  stateMachine: StateMachine<DepositToken, Deposit, DepositState>,
+  depositStore: DepositStore,
+  private val metricsClient: MetricsClient,
+): DepositController(stateMachine, metricsClient, depositStore) {
+  override fun processInputs(
+    value: Deposit,
+    inputs: List<Input<RequirementId>>,
+    operation: Operation,
+    hurdleGroupId: String?
+  ): Result<ProcessingState<Deposit, RequirementId>> = result {
+    value.transitionTo(WaitingForReversalPendingConfirmationStatus, metricsClient).bind().asProcessingState()
+  }
+
+  override fun handleFailure(
+    failure: Throwable,
+    value: Deposit
+  ): Result<Deposit> = failReversal(failure, value)
+
+}

--- a/innie/src/main/kotlin/xyz/block/bittycity/innie/controllers/DomainControllerModule.kt
+++ b/innie/src/main/kotlin/xyz/block/bittycity/innie/controllers/DomainControllerModule.kt
@@ -10,11 +10,15 @@ import xyz.block.bittycity.common.idempotency.IdempotentResumeInputs
 import xyz.block.bittycity.common.store.Transactor
 import xyz.block.bittycity.innie.models.CheckingDepositRisk
 import xyz.block.bittycity.innie.models.CheckingEligibility
+import xyz.block.bittycity.innie.models.CheckingReversalRisk
+import xyz.block.bittycity.innie.models.CheckingSanctions
+import xyz.block.bittycity.innie.models.CollectingInfo
 import xyz.block.bittycity.innie.models.Deposit
 import xyz.block.bittycity.innie.models.DepositState
 import xyz.block.bittycity.innie.models.DepositToken
 import xyz.block.bittycity.innie.models.RequirementId
 import xyz.block.bittycity.innie.models.WaitingForDepositConfirmedOnChainStatus
+import xyz.block.bittycity.innie.models.WaitingForReversal
 import xyz.block.bittycity.innie.store.ResponseOperations
 import xyz.block.domainapi.util.Controller
 
@@ -24,13 +28,21 @@ object DomainControllerModule : AbstractModule() {
   fun provideDomainController(
     onChainController: OnChainController,
     eligibilityController: EligibilityController,
-    depositRiskController: DepositRiskController
+    depositRiskController: DepositRiskController,
+    depositReversalController: DepositReversalController,
+    infoCollectionController: InfoCollectionController,
+    sanctionsController: SanctionsController,
+    depositReversalRiskController: DepositReversalRiskController
   ): DomainController<DepositToken, DepositState, Deposit, RequirementId> {
     val stateToController:
       Map<DepositState, Controller<DepositToken, DepositState, Deposit, RequirementId>> = mapOf(
         WaitingForDepositConfirmedOnChainStatus to onChainController,
         CheckingEligibility to eligibilityController,
-      CheckingDepositRisk to depositRiskController
+        CheckingDepositRisk to depositRiskController,
+        WaitingForReversal to depositReversalController,
+        CollectingInfo to infoCollectionController,
+        CheckingSanctions to sanctionsController,
+        CheckingReversalRisk to depositReversalRiskController
       ).mapValues { (_, controller) ->
         controller as Controller<DepositToken, DepositState, Deposit, RequirementId>
     }

--- a/innie/src/main/kotlin/xyz/block/bittycity/innie/controllers/InfoCollectionController.kt
+++ b/innie/src/main/kotlin/xyz/block/bittycity/innie/controllers/InfoCollectionController.kt
@@ -1,0 +1,112 @@
+package xyz.block.bittycity.innie.controllers
+
+import app.cash.kfsm.StateMachine
+import app.cash.quiver.extensions.catch
+import arrow.core.raise.result
+import jakarta.inject.Inject
+import xyz.block.bittycity.common.client.CurrencyDisplayPreferenceClient
+import xyz.block.bittycity.common.utils.WalletAddressParser
+import xyz.block.bittycity.innie.client.MetricsClient
+import xyz.block.bittycity.innie.models.CheckingSanctions
+import xyz.block.bittycity.innie.models.CollectingInfo
+import xyz.block.bittycity.innie.models.Deposit
+import xyz.block.bittycity.innie.models.DepositReversalHurdle
+import xyz.block.bittycity.innie.models.DepositReversalHurdleResponse
+import xyz.block.bittycity.innie.models.DepositState
+import xyz.block.bittycity.innie.models.DepositToken
+import xyz.block.bittycity.innie.models.RequirementId
+import xyz.block.bittycity.innie.models.RequirementId.*
+import xyz.block.bittycity.innie.store.DepositStore
+import xyz.block.bittycity.innie.validation.ParameterIsRequired
+import xyz.block.domainapi.DomainApiError.UnsupportedHurdleResultCode
+import xyz.block.domainapi.Input
+import xyz.block.domainapi.ResultCode
+import xyz.block.domainapi.UserInteraction
+
+class InfoCollectionController @Inject constructor(
+  stateMachine: StateMachine<DepositToken, Deposit, DepositState>,
+  depositStore: DepositStore,
+  metricsClient: MetricsClient,
+  private val currencyDisplayPreferenceClient: CurrencyDisplayPreferenceClient,
+  private val walletAddressParser: WalletAddressParser
+): DepositInfoCollectionController(
+  pendingCollectionState = CollectingInfo,
+  stateMachine = stateMachine,
+  depositStore = depositStore,
+  metricsClient = metricsClient,
+) {
+
+  override fun findMissingRequirements(value: Deposit): Result<List<RequirementId>> = result {
+    val reversal = Result.catch { value.reversals.last() }.bind()
+    listOf(
+      REVERSAL_TARGET_WALLET_ADDRESS to  { reversal.targetWalletAddress == null },
+      REVERSAL_USER_CONFIRMATION to { reversal.userHasConfirmed == null && reversal.targetWalletAddress != null },
+    ).filter { (_, predicate) -> predicate() }
+      .map { (key, _) -> key }
+  }
+
+  override fun getHurdlesForRequirementId(
+    requirementId: RequirementId,
+    value: Deposit,
+    previousHurdles: List<UserInteraction.Hurdle<RequirementId>>
+  ): Result<List<UserInteraction.Hurdle<RequirementId>>> = result {
+    when (requirementId) {
+      REVERSAL_TARGET_WALLET_ADDRESS -> listOf(DepositReversalHurdle.TargetWalletAddressHurdle)
+      REVERSAL_USER_CONFIRMATION -> listOf(
+        DepositReversalHurdle.ConfirmationHurdle(
+          walletAddress = value.targetWalletAddress,
+          amount = value.amount,
+          fiatEquivalent = value.fiatEquivalentAmount,
+          displayUnits = currencyDisplayPreferenceClient.getCurrencyDisplayPreference(
+            value.customerId.id
+          ).bind().bitcoinDisplayUnits
+        )
+      )
+      else -> emptyList()
+    }
+  }
+
+  override fun handleFailure(
+    failure: Throwable,
+    value: Deposit
+  ): Result<Deposit> = failReversal(failure, value)
+
+  override fun transition(value: Deposit): Result<Deposit> = result {
+    when (value.state) {
+      is CollectingInfo -> {
+        stateMachine.transitionTo(value, CheckingSanctions).bind()
+      }
+      else -> raise(IllegalStateException("Unexpected state ${value.state}"))
+    }
+  }
+
+  override fun updateValue(
+    value: Deposit,
+    hurdleResponse: Input.HurdleResponse<RequirementId>
+  ): Result<Deposit> = result {
+    when (hurdleResponse) {
+      is DepositReversalHurdleResponse.TargetWalletAddressHurdleResponse -> {
+        if (hurdleResponse.result != ResultCode.CLEARED) {
+          raise(UnsupportedHurdleResultCode(value.customerId.id, hurdleResponse.result))
+        }
+
+        val walletAddress = hurdleResponse.walletAddress
+          ?: raise(ParameterIsRequired(value.customerId, "targetWalletAddress"))
+
+        depositStore.updateDeposit(
+          value.updateCurrentReversal {
+            it.copy(targetWalletAddress = walletAddressParser.parse(walletAddress).bind())
+          }.bind()
+        )
+      }
+      is DepositReversalHurdleResponse.ConfirmationHurdleResponse -> {
+        depositStore.updateDeposit(
+          value.updateCurrentReversal {
+            it.copy(userHasConfirmed = true)
+          }.bind()
+        ).bind()
+      }
+    }
+    value
+  }
+}

--- a/innie/src/main/kotlin/xyz/block/bittycity/innie/controllers/SanctionsController.kt
+++ b/innie/src/main/kotlin/xyz/block/bittycity/innie/controllers/SanctionsController.kt
@@ -1,0 +1,35 @@
+package xyz.block.bittycity.innie.controllers
+
+import app.cash.kfsm.StateMachine
+import arrow.core.raise.result
+import jakarta.inject.Inject
+import xyz.block.bittycity.innie.client.MetricsClient
+import xyz.block.bittycity.innie.models.CheckingReversalRisk
+import xyz.block.bittycity.innie.models.Deposit
+import xyz.block.bittycity.innie.models.DepositState
+import xyz.block.bittycity.innie.models.DepositToken
+import xyz.block.bittycity.innie.models.RequirementId
+import xyz.block.bittycity.innie.store.DepositStore
+import xyz.block.domainapi.Input
+import xyz.block.domainapi.ProcessingState
+import xyz.block.domainapi.util.Operation
+
+class SanctionsController @Inject constructor(
+  stateMachine: StateMachine<DepositToken, Deposit, DepositState>,
+  depositStore: DepositStore,
+  private val metricsClient: MetricsClient,
+): DepositController(stateMachine, metricsClient, depositStore) {
+  override fun processInputs(
+    value: Deposit,
+    inputs: List<Input<RequirementId>>,
+    operation: Operation,
+    hurdleGroupId: String?
+  ): Result<ProcessingState<Deposit, RequirementId>> = result {
+    value.transitionTo(CheckingReversalRisk, metricsClient).bind().asProcessingState()
+  }
+
+  override fun handleFailure(
+    failure: Throwable,
+    value: Deposit
+  ): Result<Deposit> = failReversal(failure, value)
+}

--- a/innie/src/main/kotlin/xyz/block/bittycity/innie/controllers/ThrowableExt.kt
+++ b/innie/src/main/kotlin/xyz/block/bittycity/innie/controllers/ThrowableExt.kt
@@ -3,9 +3,14 @@ package xyz.block.bittycity.innie.controllers
 import xyz.block.bittycity.common.client.IneligibleCustomer
 import xyz.block.bittycity.common.client.RiskBlocked
 import xyz.block.bittycity.innie.models.DepositFailureReason
+import xyz.block.bittycity.innie.models.DepositReversalFailureReason
 
 fun Throwable.toFailureReason(): DepositFailureReason = when (this) {
   is IneligibleCustomer -> DepositFailureReason.INELIGIBLE
   is RiskBlocked -> DepositFailureReason.RISK_BLOCKED
   else -> DepositFailureReason.UNKNOWN
+}
+
+fun Throwable.toReversalFailureReason(): DepositReversalFailureReason = when (this) {
+  else -> DepositReversalFailureReason.UNKNOWN
 }

--- a/innie/src/main/kotlin/xyz/block/bittycity/innie/models/DepositState.kt
+++ b/innie/src/main/kotlin/xyz/block/bittycity/innie/models/DepositState.kt
@@ -96,13 +96,15 @@ data object CollectingSanctionsInfo : DepositState(
 )
 
 data object WaitingForSanctionsHeldDecision : DepositState(
-  to = { setOf(Sanctioned, WaitingForReversalPendingConfirmationStatus, WaitingForReversal) }
+  to = { setOf(Sanctioned, WaitingForReversalPendingConfirmationStatus, WaitingForReversal) },
+  processingState = { deposit, displayPref -> Waiting(deposit) }
 )
 
 data object Sanctioned : DepositState()
 
 data object WaitingForReversalPendingConfirmationStatus : DepositState(
-  to = { setOf(WaitingForReversalConfirmedOnChainStatus, WaitingForReversal) }
+  to = { setOf(WaitingForReversalConfirmedOnChainStatus, WaitingForReversal) },
+  processingState = { deposit, displayPref -> Waiting(deposit) }
 )
 
 data object WaitingForReversalConfirmedOnChainStatus : DepositState(

--- a/innie/src/main/kotlin/xyz/block/bittycity/innie/models/Hurdles.kt
+++ b/innie/src/main/kotlin/xyz/block/bittycity/innie/models/Hurdles.kt
@@ -1,9 +1,13 @@
 package xyz.block.bittycity.innie.models
 
 import org.bitcoinj.base.Address
+import org.joda.money.Money
+import xyz.block.bittycity.common.models.BitcoinDisplayUnits
 import xyz.block.bittycity.common.models.Bitcoins
-import xyz.block.bittycity.innie.models.RequirementId.DEPOSIT_CONFIRMED_ON_CHAIN
+import xyz.block.domainapi.Input.HurdleResponse
 import xyz.block.domainapi.Input.ResumeResult
+import xyz.block.domainapi.ResultCode
+import xyz.block.domainapi.UserInteraction.Hurdle
 
 sealed class DepositResumeResult(id: RequirementId) : ResumeResult<RequirementId>(id) {
   data class ConfirmedOnChain(
@@ -13,5 +17,37 @@ sealed class DepositResumeResult(id: RequirementId) : ResumeResult<RequirementId
     val amount: Bitcoins,
     val blockchainTransactionId: String,
     val blockchainTransactionOutputIndex: Int
-  ) : DepositResumeResult(DEPOSIT_CONFIRMED_ON_CHAIN)
+  ) : DepositResumeResult(RequirementId.DEPOSIT_CONFIRMED_ON_CHAIN)
+}
+
+sealed class DepositReversalHurdle(id: RequirementId) : Hurdle<RequirementId>(id) {
+  /**
+   * Hurdle used to capture a target wallet address.
+   */
+  data object TargetWalletAddressHurdle : DepositReversalHurdle(RequirementId.REVERSAL_TARGET_WALLET_ADDRESS)
+
+  /**
+   * Hurdle to capture the user's confirmation of the reversal details.
+   */
+  data class ConfirmationHurdle(
+    val walletAddress: Address?,
+    val amount: Bitcoins?,
+    val fiatEquivalent: Money?,
+    val displayUnits: BitcoinDisplayUnits
+  ) : DepositReversalHurdle(RequirementId.REVERSAL_USER_CONFIRMATION)
+}
+
+sealed class DepositReversalHurdleResponse(id: RequirementId, code: ResultCode) :
+  HurdleResponse<RequirementId>(id, code) {
+  /**
+   * Hurdle result with the target wallet address. The address should be present if the hurdle
+   * was cleared successfully (i.e. result is [ResultCode.CLEARED]).
+   */
+  data class TargetWalletAddressHurdleResponse(
+    val code: ResultCode,
+    val walletAddress: String? = null,
+  ) : DepositReversalHurdleResponse(RequirementId.REVERSAL_TARGET_WALLET_ADDRESS, code)
+
+  data class ConfirmationHurdleResponse(val code: ResultCode) :
+    DepositReversalHurdleResponse(RequirementId.REVERSAL_USER_CONFIRMATION, code)
 }

--- a/innie/src/main/kotlin/xyz/block/bittycity/innie/validation/ValidationService.kt
+++ b/innie/src/main/kotlin/xyz/block/bittycity/innie/validation/ValidationService.kt
@@ -1,0 +1,11 @@
+package xyz.block.bittycity.innie.validation
+
+import xyz.block.bittycity.common.models.CustomerId
+import xyz.block.domainapi.InfoOnly
+
+sealed class ValidationError :
+  Exception(),
+  InfoOnly
+
+data class ParameterIsRequired(val customerId: CustomerId, val parameter: String) :
+  ValidationError()

--- a/innie/src/test/kotlin/xyz/block/bittycity/innie/controllers/DepositReversalControllerTest.kt
+++ b/innie/src/test/kotlin/xyz/block/bittycity/innie/controllers/DepositReversalControllerTest.kt
@@ -1,0 +1,57 @@
+package xyz.block.bittycity.innie.controllers
+
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.result.shouldBeSuccess
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.property.arbitrary.next
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Test
+import xyz.block.bittycity.innie.api.DepositDomainController
+import xyz.block.bittycity.innie.models.CollectingInfo
+import xyz.block.bittycity.innie.models.DepositFailureReason.RISK_BLOCKED
+import xyz.block.bittycity.innie.models.DepositReversal
+import xyz.block.bittycity.innie.models.DepositReversalHurdle
+import xyz.block.bittycity.innie.models.WaitingForReversal
+import xyz.block.bittycity.innie.testing.Arbitrary
+import xyz.block.bittycity.innie.testing.Arbitrary.amount
+import xyz.block.bittycity.innie.testing.Arbitrary.customerId
+import xyz.block.bittycity.innie.testing.Arbitrary.exchangeRate
+import xyz.block.bittycity.innie.testing.Arbitrary.outputIndex
+import xyz.block.bittycity.innie.testing.Arbitrary.stringToken
+import xyz.block.bittycity.innie.testing.Arbitrary.walletAddress
+import xyz.block.bittycity.innie.testing.BittyCityTestCase
+import xyz.block.domainapi.util.Operation
+
+class DepositReversalControllerTest : BittyCityTestCase() {
+
+  @Inject lateinit var subject: DepositDomainController
+
+  @Test
+  fun `Starting a reversal returns hurdles for target wallet address and confirmation`() = runTest {
+    val deposit = data.seedDeposit(
+      state = WaitingForReversal,
+      customerId = customerId.next(),
+      amount = amount.next(),
+      exchangeRate = exchangeRate.next(),
+      targetWalletAddress = walletAddress.next(),
+      blockchainTransactionId = stringToken.next(),
+      blockchainTransactionOutputIndex = outputIndex.next(),
+      paymentToken = stringToken.next(),
+      reversals = listOf(
+        DepositReversal(Arbitrary.depositReversalToken.next())
+      )
+    ) {
+      it.copy(failureReason = RISK_BLOCKED)
+    }
+
+    val response = subject.execute(deposit, emptyList(), Operation.EXECUTE).shouldBeSuccess()
+    response.interactions shouldHaveSize 1
+    response.interactions[0] shouldBe DepositReversalHurdle.TargetWalletAddressHurdle
+
+    depositWithToken(deposit.id) should {
+      it.state shouldBe CollectingInfo
+      it.failureReason shouldBe RISK_BLOCKED
+    }
+  }
+}

--- a/innie/src/test/kotlin/xyz/block/bittycity/innie/testing/Arbitrary.kt
+++ b/innie/src/test/kotlin/xyz/block/bittycity/innie/testing/Arbitrary.kt
@@ -20,6 +20,7 @@ import xyz.block.bittycity.common.models.CustomerId
 import xyz.block.bittycity.innie.models.CheckingDepositRisk.allStates
 import xyz.block.bittycity.innie.models.DepositFailureReason
 import xyz.block.bittycity.innie.models.DepositReversalFailureReason
+import xyz.block.bittycity.innie.models.DepositReversalToken
 import xyz.block.bittycity.innie.models.DepositState
 import xyz.block.bittycity.innie.models.DepositToken
 import java.util.UUID
@@ -30,6 +31,7 @@ object Arbitrary {
     Arb.stringPattern("[a-z0-9]{12}").map { CustomerId(it) }
   val stringToken: Arb<String> = Arb.stringPattern("[a-z0-9]{12}")
   val depositToken: Arb<DepositToken> = stringToken.map { DepositToken(it) }
+  val depositReversalToken : Arb<DepositReversalToken> = uuid.map { DepositReversalToken(it) }
   val walletAddress: Arb<Address> = arbitrary {
     ECKey().toAddress(ScriptType.P2WPKH, BitcoinNetwork.TESTNET)
   }

--- a/innie/src/test/kotlin/xyz/block/bittycity/innie/testing/BittyCityTestModule.kt
+++ b/innie/src/test/kotlin/xyz/block/bittycity/innie/testing/BittyCityTestModule.kt
@@ -1,6 +1,14 @@
 package xyz.block.bittycity.innie.testing
 
+import com.google.inject.Scopes
+import org.bitcoinj.base.BitcoinNetwork
+import xyz.block.bittycity.common.utils.WalletAddressParser
 import xyz.block.bittycity.innie.InnieModule
 
 object BittyCityTestModule : InnieModule() {
+
+  override fun installValidationModule() {
+    bind(WalletAddressParser::class.java).`in`(Scopes.SINGLETON)
+    bind(BitcoinNetwork::class.java).toInstance(BitcoinNetwork.TESTNET)
+  }
 }

--- a/innie/src/test/kotlin/xyz/block/bittycity/innie/testing/FakeMetricsClient.kt
+++ b/innie/src/test/kotlin/xyz/block/bittycity/innie/testing/FakeMetricsClient.kt
@@ -5,6 +5,7 @@ import app.cash.quiver.extensions.success
 import xyz.block.bittycity.innie.client.MetricsClient
 import xyz.block.bittycity.innie.models.Deposit
 import xyz.block.bittycity.innie.models.DepositFailureReason
+import xyz.block.bittycity.innie.models.DepositReversalFailureReason
 import xyz.block.bittycity.innie.models.DepositState
 
 class FakeMetricsClient : TestFake(), MetricsClient {
@@ -16,6 +17,8 @@ class FakeMetricsClient : TestFake(), MetricsClient {
   ): Result<Unit> = Unit.success()
 
   override fun failureReason(reason: DepositFailureReason): Result<Unit> = Unit.success()
+
+  override fun reversalFailureReason(reason: DepositReversalFailureReason): Result<Unit> = Unit.success()
 
   override fun depositSuccessAmount(deposit: Deposit): Result<Unit> = Unit.success()
 }

--- a/innie/src/test/kotlin/xyz/block/bittycity/innie/testing/TestApp.kt
+++ b/innie/src/test/kotlin/xyz/block/bittycity/innie/testing/TestApp.kt
@@ -7,6 +7,7 @@ import org.joda.money.Money
 import xyz.block.bittycity.common.models.Bitcoins
 import xyz.block.bittycity.common.models.CustomerId
 import xyz.block.bittycity.innie.models.Deposit
+import xyz.block.bittycity.innie.models.DepositReversal
 import xyz.block.bittycity.innie.models.DepositState
 import xyz.block.bittycity.innie.models.DepositToken
 import xyz.block.bittycity.innie.store.DepositStore
@@ -38,6 +39,7 @@ class TestApp {
     blockchainTransactionId: String,
     blockchainTransactionOutputIndex: Int,
     paymentToken: String,
+    reversals: List<DepositReversal> = emptyList(),
     modifier: (Deposit) -> Deposit = { it },
   ): Deposit {
     val inserted = depositStore.insertDeposit(
@@ -51,7 +53,8 @@ class TestApp {
         targetWalletAddress = targetWalletAddress,
         blockchainTransactionId = blockchainTransactionId,
         blockchainTransactionOutputIndex = blockchainTransactionOutputIndex,
-        paymentToken = paymentToken
+        paymentToken = paymentToken,
+        reversals = reversals
       )
     ).getOrThrow()
 

--- a/outie-jooq-provider/src/main/kotlin/xyz/block/bittycity/outie/jooq/JooqWithdrawalEntityOperations.kt
+++ b/outie-jooq-provider/src/main/kotlin/xyz/block/bittycity/outie/jooq/JooqWithdrawalEntityOperations.kt
@@ -29,7 +29,7 @@ import xyz.block.bittycity.outie.models.WithdrawalSpeedOption
 import xyz.block.bittycity.outie.models.WithdrawalState
 import xyz.block.bittycity.outie.models.WithdrawalToken
 import xyz.block.bittycity.outie.store.WithdrawalEntityOperations
-import xyz.block.bittycity.outie.validation.WalletAddressParser
+import xyz.block.bittycity.common.utils.WalletAddressParser
 import xyz.block.domainapi.InfoOnly
 import java.time.Clock
 import java.time.Instant

--- a/outie-jooq-provider/src/main/kotlin/xyz/block/bittycity/outie/jooq/JooqWithdrawalOperations.kt
+++ b/outie-jooq-provider/src/main/kotlin/xyz/block/bittycity/outie/jooq/JooqWithdrawalOperations.kt
@@ -5,7 +5,7 @@ import org.jooq.DSLContext
 import xyz.block.bittycity.outie.store.WithdrawalEntityOperations
 import xyz.block.bittycity.outie.store.WithdrawalEventOperations
 import xyz.block.bittycity.outie.store.WithdrawalOperations
-import xyz.block.bittycity.outie.validation.WalletAddressParser
+import xyz.block.bittycity.common.utils.WalletAddressParser
 import java.time.Clock
 
 class JooqWithdrawalOperations(

--- a/outie/src/main/kotlin/xyz/block/bittycity/outie/controllers/InfoCollectionController.kt
+++ b/outie/src/main/kotlin/xyz/block/bittycity/outie/controllers/InfoCollectionController.kt
@@ -47,7 +47,7 @@ import xyz.block.bittycity.outie.validation.InvalidBlockTarget
 import xyz.block.bittycity.outie.validation.ParameterIsRequired
 import xyz.block.bittycity.outie.validation.ValidationService
 import xyz.block.bittycity.outie.validation.ValidationService.Companion.MAX_NOTE_LENGTH
-import xyz.block.bittycity.outie.validation.WalletAddressParser
+import xyz.block.bittycity.common.utils.WalletAddressParser
 import jakarta.inject.Inject
 import jakarta.inject.Named
 import org.joda.money.Money

--- a/outie/src/main/kotlin/xyz/block/bittycity/outie/validation/ValidationModule.kt
+++ b/outie/src/main/kotlin/xyz/block/bittycity/outie/validation/ValidationModule.kt
@@ -5,6 +5,7 @@ import com.google.inject.Provides
 import com.google.inject.Scopes
 import jakarta.inject.Singleton
 import org.bitcoinj.base.BitcoinNetwork
+import xyz.block.bittycity.common.utils.WalletAddressParser
 
 object ValidationModule : AbstractModule() {
   @Provides

--- a/outie/src/test/kotlin/xyz/block/bittycity/outie/testing/BittyCityTestModule.kt
+++ b/outie/src/test/kotlin/xyz/block/bittycity/outie/testing/BittyCityTestModule.kt
@@ -15,7 +15,7 @@ import xyz.block.bittycity.outie.store.ResponseOperations
 import xyz.block.bittycity.outie.store.TestPersistenceModule.Companion.DATASOURCE
 import xyz.block.bittycity.common.store.Transactor
 import xyz.block.bittycity.outie.store.WithdrawalOperations
-import xyz.block.bittycity.outie.validation.WalletAddressParser
+import xyz.block.bittycity.common.utils.WalletAddressParser
 
 object BittyCityTestModule : OutieModule() {
 


### PR DESCRIPTION
### TL;DR

Start implementing deposit reversal functionality and move wallet address parsing to common module.

### What changed?

- Moved `WalletAddressParser` from `outie` to `common` module to enable reuse
- Added dependencies for `bitcoinj` and `guice` to the common module
- Implemented deposit reversal flow with new controllers:
  - `DepositReversalController`: Initiates the reversal process
  - `InfoCollectionController`: Collects wallet address and user confirmation
  - `SanctionsController`: No-op, for testing only
  - `DepositReversalRiskController`: No-op, for testing only
- Added new deposit states to support the reversal flow
- Created new hurdles for collecting wallet address and user confirmation
- Added metrics for tracking reversal failures
