### PR TITLE
Revert Kotlin to 2.2.21 for binary compatibility

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ kfsm = "0.12.0"
 kotest = "5.9.1"
 kotestArrow = "2.0.0"
 # @pin
-kotlin = "2.3.0"
+kotlin = "2.2.21"
 kotlinBinaryCompatibilityPlugin = "0.18.1"
 kotlinLogging = "7.0.13"
 mavenPublish = "0.35.0"


### PR DESCRIPTION
## Problem

Kotlin 2.3.0 introduced binary incompatibility that breaks downstream consumers still on Kotlin 2.1.x (including Square internal services).

## Solution

This PR reverts Kotlin from 2.3.0 back to 2.2.21 (reverting commit 567058f)
These versions match what was in v0.0.4 and maintain binary compatibility with consumers using Kotlin 2.1.x.

## Testing

- ✅ All tests pass locally with Kotlin 2.2.21
- ✅ Build succeeds

## Next Steps

After merge, will release v0.0.6 with these reverted versions.

## Future Work

- Configure Renovate to prevent auto-merging Kotlin major version upgrades, requiring manual review to coordinate with downstream consumers.