### PR TITLE
[SQBTC-1444] Return InvalidProcessState when an operation is attempted on a failed withdrawal

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 arrow = "2.2.1"
 bitcoinj = "0.17"
-domainApi = "0.1.1"
+domainApi = "0.3.0"
 flyway = "11.20.2"
 guice = "7.0.0"
 hikari = "7.0.2"

--- a/outie/src/main/kotlin/xyz/block/bittycity/outie/controllers/DomainControllerModule.kt
+++ b/outie/src/main/kotlin/xyz/block/bittycity/outie/controllers/DomainControllerModule.kt
@@ -25,6 +25,7 @@ import xyz.block.bittycity.outie.models.Withdrawal
 import xyz.block.bittycity.outie.models.WithdrawalState
 import xyz.block.bittycity.outie.models.WithdrawalToken
 import jakarta.inject.Singleton
+import xyz.block.bittycity.outie.models.Failed
 import xyz.block.domainapi.util.Controller
 
 object DomainControllerModule : AbstractModule() {
@@ -42,6 +43,7 @@ object DomainControllerModule : AbstractModule() {
     scamWarningController: ScamWarningController,
     travelRuleController: TravelRuleController,
     onChainController: OnChainController,
+    failedController: FailedController,
   ): DomainController<WithdrawalToken, WithdrawalState, Withdrawal, RequirementId> {
     val stateToController:
       Map<WithdrawalState, Controller<WithdrawalToken, WithdrawalState, Withdrawal, RequirementId>> =
@@ -76,6 +78,7 @@ object DomainControllerModule : AbstractModule() {
         SubmittingOnChain to onChainController,
         WaitingForPendingConfirmationStatus to onChainController,
         WaitingForConfirmedOnChainStatus to onChainController,
+        Failed to failedController,
       ).mapValues { (_, controller) ->
         @Suppress("UNCHECKED_CAST")
         controller as Controller<WithdrawalToken, WithdrawalState, Withdrawal, RequirementId>

--- a/outie/src/main/kotlin/xyz/block/bittycity/outie/controllers/FailedController.kt
+++ b/outie/src/main/kotlin/xyz/block/bittycity/outie/controllers/FailedController.kt
@@ -1,0 +1,39 @@
+package xyz.block.bittycity.outie.controllers
+
+import app.cash.kfsm.StateMachine
+import arrow.core.raise.result
+import jakarta.inject.Inject
+import xyz.block.bittycity.outie.client.MetricsClient
+import xyz.block.bittycity.outie.models.RequirementId
+import xyz.block.bittycity.outie.models.Withdrawal
+import xyz.block.bittycity.outie.models.WithdrawalState
+import xyz.block.bittycity.outie.models.WithdrawalToken
+import xyz.block.bittycity.outie.store.WithdrawalStore
+import xyz.block.domainapi.DomainApiError
+import xyz.block.domainapi.Input
+import xyz.block.domainapi.ProcessingState
+import xyz.block.domainapi.util.Operation
+
+class FailedController @Inject constructor(
+  stateMachine: StateMachine<WithdrawalToken, Withdrawal, WithdrawalState>,
+  withdrawalStore: WithdrawalStore,
+  metricsClient: MetricsClient,
+) : WithdrawalController(stateMachine, metricsClient, withdrawalStore) {
+
+  override fun processInputs(
+    value: Withdrawal,
+    inputs: List<Input<RequirementId>>,
+    operation: Operation,
+    hurdleGroupId: String?
+  ): Result<ProcessingState<Withdrawal, RequirementId>> = result {
+    raise(DomainApiError.InvalidProcessState(value.id.toString(), "Withdrawal is in failed state"))
+  }
+
+  override fun handleFailure(
+    failure: Throwable,
+    value: Withdrawal
+  ): Result<Withdrawal> = result {
+    // Do nothing - withdrawal is already failed
+    raise(failure)
+  }
+}

--- a/outie/src/test/kotlin/xyz/block/bittycity/outie/controllers/FailedControllerTest.kt
+++ b/outie/src/test/kotlin/xyz/block/bittycity/outie/controllers/FailedControllerTest.kt
@@ -1,0 +1,40 @@
+package xyz.block.bittycity.outie.controllers
+
+import io.kotest.matchers.result.shouldBeFailure
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.property.arbitrary.next
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Test
+import xyz.block.bittycity.outie.api.WithdrawalDomainController
+import xyz.block.bittycity.outie.models.Failed
+import xyz.block.bittycity.outie.models.FailureReason
+import xyz.block.bittycity.outie.testing.Arbitrary
+import xyz.block.bittycity.outie.testing.BittyCityTestCase
+import xyz.block.domainapi.DomainApiError
+import xyz.block.domainapi.util.Operation
+
+class FailedControllerTest  : BittyCityTestCase() {
+
+  @Inject lateinit var subject: WithdrawalDomainController
+
+  @Test
+  fun `Operating on a failed withdrawal returns an InvalidProcessState error`() = runTest {
+    val withdrawal = data.seedWithdrawal(
+      state = Failed,
+      walletAddress = Arbitrary.walletAddress.next(),
+      amount = Arbitrary.bitcoins.next(),
+    ) { it.copy(failureReason = FailureReason.RISK_BLOCKED) }
+
+    subject.execute(
+      withdrawal,
+      emptyList(),
+      Operation.EXECUTE
+    ).shouldBeFailure<DomainApiError.InvalidProcessState>()
+
+    withdrawalWithToken(withdrawal.id) should {
+      it.state shouldBe Failed
+      it.failureReason shouldBe FailureReason.RISK_BLOCKED
+    }
+  }
+}


### PR DESCRIPTION
### TL;DR

Added a new `FailedController` to handle withdrawals in the failed state and updated the domain API version.

### What changed?

- Updated the domain API version from 0.1.1 to 0.3.0 in the Gradle dependencies
- Created a new `FailedController` class to handle withdrawals that are in the failed state
- Added the `FailedController` to the `DomainControllerModule` and mapped it to the `Failed` state
- Implemented the controller to reject any processing attempts on failed withdrawals with an `InvalidProcessState` error
- Added tests to verify that operations on failed withdrawals return the appropriate error

### How to test?

1. Run the `FailedControllerTest` to verify that operations on failed withdrawals return an `InvalidProcessState` error
2. Verify that a withdrawal in the `Failed` state with a failure reason maintains its state and reason when an operation is attempted

### Why make this change?

This change improves error handling by properly managing withdrawals that have reached a failed state. By adding a dedicated controller for the `Failed` state, we ensure that no further processing can occur on withdrawals that have already failed, maintaining data integrity and providing clear error messages to clients.