### PR TITLE
add missing moshi adapters for deposits

### DIFF
--- a/innie/src/main/kotlin/xyz/block/bittycity/innie/json/DepositMoshi.kt
+++ b/innie/src/main/kotlin/xyz/block/bittycity/innie/json/DepositMoshi.kt
@@ -9,7 +9,10 @@ import com.squareup.moshi.ToJson
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import xyz.block.bittycity.common.models.Bitcoins
 import xyz.block.bittycity.common.models.CustomerId
+import xyz.block.bittycity.innie.models.DepositReversalToken
+import xyz.block.bittycity.innie.models.DepositState
 import xyz.block.bittycity.innie.models.DepositToken
+import xyz.block.bittycity.innie.models.WaitingForDepositConfirmedOnChainStatus
 import java.time.Instant
 
 /**
@@ -22,6 +25,8 @@ object DepositMoshi {
     .add(BitcoinsAdapter())
     .add(CustomerIdAdapter())
     .add(DepositTokenAdapter())
+    .add(DepositReversalTokenAdapter())
+    .add(DepositStateAdapter())
     .add(RequirementIdJsonAdapter)
     .addLast(KotlinJsonAdapterFactory())
     .build()
@@ -55,7 +60,24 @@ object DepositMoshi {
     fun toJson(token: DepositToken): String = token.toString()
 
     @FromJson
-    fun fromJson(token: String): DepositToken = DepositToken.create(token)
+    fun fromJson(token: String): DepositToken = DepositToken.parse(token).getOrThrow()
+  }
+
+  class DepositReversalTokenAdapter {
+    @ToJson
+    fun toJson(token: DepositReversalToken): String = token.toString()
+
+    @FromJson
+    fun fromJson(token: String): DepositReversalToken = DepositReversalToken.parse(token).getOrThrow()
+  }
+
+  class DepositStateAdapter {
+    @ToJson
+    fun toJson(state: DepositState): String = state.name
+
+    @FromJson
+    fun fromJson(name: String): DepositState =
+      WaitingForDepositConfirmedOnChainStatus.byName(name).getOrThrow()
   }
 
   object RequirementIdJsonAdapter : JsonAdapter<xyz.block.bittycity.innie.models.RequirementId>() {

--- a/innie/src/test/kotlin/xyz/block/bittycity/innie/testing/Arbitrary.kt
+++ b/innie/src/test/kotlin/xyz/block/bittycity/innie/testing/Arbitrary.kt
@@ -30,7 +30,7 @@ object Arbitrary {
   val customerToken: Arb<CustomerId> =
     Arb.stringPattern("[a-z0-9]{12}").map { CustomerId(it) }
   val stringToken: Arb<String> = Arb.stringPattern("[a-z0-9]{12}")
-  val depositToken: Arb<DepositToken> = stringToken.map { DepositToken(it) }
+  val depositToken: Arb<DepositToken> = uuid.map { DepositToken(it) }
   val depositReversalToken : Arb<DepositReversalToken> = uuid.map { DepositReversalToken(it) }
   val walletAddress: Arb<Address> = arbitrary {
     ECKey().toAddress(ScriptType.P2WPKH, BitcoinNetwork.TESTNET)


### PR DESCRIPTION
### Background
When I was beginning to use the deposits library, I found that a few moshi adapters were missing, so this PR adds them. Additionally, DepositToken was not following the pattern of using UUID/parse that we use on tokens, so I updated that

### Changes made
1. Add missing moshi adapters
2. Base DepositToken on UUID
