### PR TITLE
add deposit db errors

### DIFF
--- a/innie/src/main/kotlin/xyz/block/bittycity/innie/store/DepositEntityOperations.kt
+++ b/innie/src/main/kotlin/xyz/block/bittycity/innie/store/DepositEntityOperations.kt
@@ -3,6 +3,7 @@ package xyz.block.bittycity.innie.store
 import xyz.block.bittycity.innie.models.Deposit
 import xyz.block.bittycity.innie.models.DepositReversal
 import xyz.block.bittycity.innie.models.DepositToken
+import xyz.block.domainapi.InfoOnly
 
 interface DepositEntityOperations {
 
@@ -18,3 +19,22 @@ interface DepositEntityOperations {
 
   fun getLatestReversal(id: DepositToken): Result<DepositReversal?>
 }
+
+sealed class DepositStoreError(message: String) :
+  Exception(message),
+  InfoOnly
+
+class DepositNotPresent(val depositToken: DepositToken) :
+  DepositStoreError("Deposit not present: $depositToken")
+
+class DepositTokensEmpty : DepositStoreError("Deposit tokens not present")
+
+class TooManyDepositTokens(val depositTokenCount: Int, val depositTokenLimit: Int) :
+  DepositStoreError(
+    "Too many deposit tokens: $depositTokenCount, exceeded limit: $depositTokenLimit"
+  )
+
+class DepositVersionMismatch(val deposit: Deposit) :
+  DepositStoreError(
+    "Deposit not at expected version ${deposit.version}: ${deposit.id}"
+  )


### PR DESCRIPTION
### Background
Currently the library does not provide a set of errors to differentiate db read/write issues. Adding these!

### Changes made
1. Added 4 specific db errors for btc deposits