### PR TITLE
Bump innie version to 0.0.7

### DIFF
--- a/innie/gradle.properties
+++ b/innie/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.0.6
+VERSION_NAME=0.0.7
 
 POM_ARTIFACT_ID=innie
 POM_NAME=Bitty City - Innie


### PR DESCRIPTION
## Summary
- Updates innie version from 0.0.6 to 0.0.7 in gradle.properties

## Next Steps
After merging this PR, create and push the tag to publish:
```bash
git checkout main
git pull
git tag innie-v0.0.7
git push origin innie-v0.0.7
```