### PR TITLE
pin kotlin, bump innie

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ kfsm = "0.12.0"
 kotest = "5.9.1"
 kotestArrow = "2.0.0"
 # @pin
-kotlin = "2.3.0"
+kotlin = "2.2.21"
 kotlinBinaryCompatibilityPlugin = "0.18.1"
 kotlinLogging = "7.0.14"
 mavenPublish = "0.36.0"

--- a/innie/gradle.properties
+++ b/innie/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.0.7
+VERSION_NAME=0.0.8
 
 POM_ARTIFACT_ID=innie
 POM_NAME=Bitty City - Innie

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,13 @@
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
   "packageRules": [
     {
-      "matchPackageNames": ["org.jetbrains.kotlin.**"],
+      "matchManagers": ["gradle-version-catalog"],
+      "matchPackageNames": ["kotlin"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["gradle"],
+      "matchPackageNames": ["org.jetbrains.kotlin:.*"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
### 1 Fix Renovate exclusion
Because Renovate updated the version alias kotlin in the version catalog, not the module org.jetbrains.kotlin:kotlin-reflect, and your rule only matched module coordinates. In libs.versions.toml, Renovate treats version keys like kotlin as separate dependencies, so org.jetbrains.kotlin.** never matched.

### 2 Return kotlin version to 2.2.21
I imported 0.0.7 version of innie but since it was on 2.3.0 kotlin, it doesn't work

### 3 Bump innie version
0.0.7 is busted for our usage, so bumping to 0.0.8