### PR TITLE
rotate wallet address to wallet client

### DIFF
--- a/innie/src/main/kotlin/xyz/block/bittycity/innie/client/WalletClient.kt
+++ b/innie/src/main/kotlin/xyz/block/bittycity/innie/client/WalletClient.kt
@@ -5,4 +5,12 @@ import xyz.block.bittycity.common.models.CustomerId
 
 interface WalletClient {
   fun lookupWallet(address: Address): Result<CustomerId?>
+
+  /**
+   * Rotates the wallet address for a given customer.
+   *
+   * @param customerId The ID of the customer whose wallet address should be rotated.
+   * @return a [Result] containing the new wallet [Address] if successful.
+   */
+  fun rotateWalletAddress(customerId: CustomerId): Result<Address>
 }


### PR DESCRIPTION
Once a customer successfully completes a deposit, we should update/rotate the wallet address of the customer