### PR TITLE
Prepare for release outie 0.2.1

### DIFF
--- a/outie/CHANGELOG.md
+++ b/outie/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [0.2.1]
+
+* Moved withdrawal eligibility client contract to common EligibilityClient.
+
+
 ## [0.2.0]
 
 * Moved BalanceId, BitcoinAccount and BitcoinAccount to the common module, because they are reusable across withdrawals and deposits.

--- a/outie/gradle.properties
+++ b/outie/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.2.0
+VERSION_NAME=0.2.1
 
 POM_ARTIFACT_ID=outie
 POM_NAME=Bitty City - Outie


### PR DESCRIPTION
## Summary
- bump outie version from 0.2.0 to 0.2.1
- add changelog entry for 0.2.1

## Verification
- ./bin/gradle :outie:build