### PR TITLE
[SQBTC-1320] Add support for searching deposits by reversal token

### DIFF
--- a/innie/src/main/kotlin/xyz/block/bittycity/innie/store/DepositEntityOperations.kt
+++ b/innie/src/main/kotlin/xyz/block/bittycity/innie/store/DepositEntityOperations.kt
@@ -6,6 +6,7 @@ import xyz.block.bittycity.common.models.Bitcoins
 import xyz.block.bittycity.common.models.CustomerId
 import xyz.block.bittycity.innie.models.Deposit
 import xyz.block.bittycity.innie.models.DepositReversal
+import xyz.block.bittycity.innie.models.DepositReversalToken
 import xyz.block.bittycity.innie.models.DepositState
 import xyz.block.bittycity.innie.models.DepositToken
 import xyz.block.domainapi.InfoOnly
@@ -31,7 +32,8 @@ interface DepositEntityOperations {
     maxAmount: Bitcoins? = null,
     states: Set<DepositState> = setOf(),
     targetWalletAddress: Address? = null,
-    paymentToken: String? = null
+    paymentToken: String? = null,
+    reversalToken: DepositReversalToken? = null
   ): Result<List<Deposit>>
 
   fun addReversal(id: DepositToken, reversal: DepositReversal): Result<DepositReversal>

--- a/innie/src/main/kotlin/xyz/block/bittycity/innie/store/DepositStore.kt
+++ b/innie/src/main/kotlin/xyz/block/bittycity/innie/store/DepositStore.kt
@@ -7,6 +7,7 @@ import xyz.block.bittycity.common.store.Transactor
 import xyz.block.bittycity.common.models.Bitcoins
 import xyz.block.bittycity.common.models.CustomerId
 import xyz.block.bittycity.innie.models.Deposit
+import xyz.block.bittycity.innie.models.DepositReversalToken
 import xyz.block.bittycity.innie.models.DepositState
 import xyz.block.bittycity.innie.models.DepositToken
 import java.time.Instant
@@ -41,7 +42,8 @@ class DepositStore @Inject constructor(
     maxAmount: Bitcoins? = null,
     states: Set<DepositState> = setOf(),
     targetWalletAddress: Address? = null,
-    paymentToken: String? = null
+    paymentToken: String? = null,
+    reversalToken: DepositReversalToken? = null
   ): Result<List<Deposit>> = depositTransactor.transactReadOnly("Search deposits") {
     searchDeposits(
       customerId = customerId,
@@ -51,7 +53,8 @@ class DepositStore @Inject constructor(
       maxAmount = maxAmount,
       states = states,
       targetWalletAddress = targetWalletAddress,
-      paymentToken = paymentToken
+      paymentToken = paymentToken,
+      reversalToken = reversalToken
     )
   }
 }

--- a/innie/src/test/kotlin/xyz/block/bittycity/innie/store/DepositStoreSearchTest.kt
+++ b/innie/src/test/kotlin/xyz/block/bittycity/innie/store/DepositStoreSearchTest.kt
@@ -6,9 +6,11 @@ import io.kotest.property.arbitrary.next
 import jakarta.inject.Inject
 import org.junit.jupiter.api.Test
 import xyz.block.bittycity.innie.models.AwaitingDepositConfirmation
+import xyz.block.bittycity.innie.models.DepositReversal
 import xyz.block.bittycity.innie.testing.Arbitrary.amount
 import xyz.block.bittycity.innie.testing.Arbitrary.balanceId
 import xyz.block.bittycity.innie.testing.Arbitrary.customerId
+import xyz.block.bittycity.innie.testing.Arbitrary.depositReversalToken
 import xyz.block.bittycity.innie.testing.Arbitrary.exchangeRate
 import xyz.block.bittycity.innie.testing.Arbitrary.outputIndex
 import xyz.block.bittycity.innie.testing.Arbitrary.stringToken
@@ -47,6 +49,43 @@ class DepositStoreSearchTest : BittyCityTestCase() {
     val result = subject.search(
       customerId = null,
       paymentToken = searchedPaymentToken
+    ).getOrThrow()
+
+    result shouldHaveSize 1
+    result.map { it.id } shouldContainExactlyInAnyOrder listOf(matching.id)
+  }
+
+  @Test
+  fun `search filters by reversal token`() = runTest {
+    val searchedReversalToken = depositReversalToken.next()
+    val matching = data.seedDeposit(
+      state = AwaitingDepositConfirmation,
+      customerId = customerId.next(),
+      amount = amount.next(),
+      exchangeRate = exchangeRate.next(),
+      targetWalletAddress = walletAddress.next(),
+      blockchainTransactionId = stringToken.next(),
+      blockchainTransactionOutputIndex = outputIndex.next(),
+      paymentToken = stringToken.next(),
+      sourceBalanceToken = balanceId.next(),
+      reversals = listOf(DepositReversal(token = searchedReversalToken))
+    )
+    data.seedDeposit(
+      state = AwaitingDepositConfirmation,
+      customerId = customerId.next(),
+      amount = amount.next(),
+      exchangeRate = exchangeRate.next(),
+      targetWalletAddress = walletAddress.next(),
+      blockchainTransactionId = stringToken.next(),
+      blockchainTransactionOutputIndex = outputIndex.next(),
+      paymentToken = stringToken.next(),
+      sourceBalanceToken = balanceId.next(),
+      reversals = listOf(DepositReversal(token = depositReversalToken.next()))
+    )
+
+    val result = subject.search(
+      customerId = null,
+      reversalToken = searchedReversalToken
     ).getOrThrow()
 
     result shouldHaveSize 1

--- a/innie/src/test/kotlin/xyz/block/bittycity/innie/testing/FakeDepositEntityOperations.kt
+++ b/innie/src/test/kotlin/xyz/block/bittycity/innie/testing/FakeDepositEntityOperations.kt
@@ -8,6 +8,7 @@ import xyz.block.bittycity.common.models.Bitcoins
 import xyz.block.bittycity.common.models.CustomerId
 import xyz.block.bittycity.innie.models.Deposit
 import xyz.block.bittycity.innie.models.DepositReversal
+import xyz.block.bittycity.innie.models.DepositReversalToken
 import xyz.block.bittycity.innie.models.DepositState
 import xyz.block.bittycity.innie.models.DepositToken
 import xyz.block.bittycity.innie.store.DepositEntityOperations
@@ -68,7 +69,8 @@ class FakeDepositEntityOperations : DepositEntityOperations {
     maxAmount: Bitcoins?,
     states: Set<DepositState>,
     targetWalletAddress: Address?,
-    paymentToken: String?
+    paymentToken: String?,
+    reversalToken: DepositReversalToken?
   ): Result<List<Deposit>> = result {
     deposits.values.filter { deposit ->
       (customerId == null || deposit.customerId == customerId) &&
@@ -78,7 +80,8 @@ class FakeDepositEntityOperations : DepositEntityOperations {
         (maxAmount == null || deposit.amount.units <= maxAmount.units) &&
         (states.isEmpty() || deposit.state in states) &&
         (targetWalletAddress == null || deposit.targetWalletAddress == targetWalletAddress) &&
-        (paymentToken == null || deposit.paymentToken == paymentToken)
+        (paymentToken == null || deposit.paymentToken == paymentToken) &&
+        (reversalToken == null || deposit.reversals.any { it.token == reversalToken })
     }
   }
 

--- a/innie/src/test/kotlin/xyz/block/bittycity/innie/testing/FakeDepositOperations.kt
+++ b/innie/src/test/kotlin/xyz/block/bittycity/innie/testing/FakeDepositOperations.kt
@@ -6,6 +6,7 @@ import xyz.block.bittycity.common.models.Bitcoins
 import xyz.block.bittycity.common.models.CustomerId
 import xyz.block.bittycity.innie.models.Deposit
 import xyz.block.bittycity.innie.models.DepositReversal
+import xyz.block.bittycity.innie.models.DepositReversalToken
 import xyz.block.bittycity.innie.models.DepositState
 import xyz.block.bittycity.innie.models.DepositToken
 import xyz.block.bittycity.innie.models.DepositTransitionEvent
@@ -46,7 +47,8 @@ class FakeDepositOperations(
     maxAmount: Bitcoins?,
     states: Set<DepositState>,
     targetWalletAddress: Address?,
-    paymentToken: String?
+    paymentToken: String?,
+    reversalToken: DepositReversalToken?
   ): Result<List<Deposit>> = entityOps.searchDeposits(
     customerId = customerId,
     from = from,
@@ -55,7 +57,8 @@ class FakeDepositOperations(
     maxAmount = maxAmount,
     states = states,
     targetWalletAddress = targetWalletAddress,
-    paymentToken = paymentToken
+    paymentToken = paymentToken,
+    reversalToken = reversalToken
   )
 
   override fun addReversal(id: DepositToken, reversal: DepositReversal): Result<DepositReversal> =


### PR DESCRIPTION
### TL;DR

Added support for filtering deposits by reversal token.

### What changed?

- Added `reversalToken` parameter to `searchDeposits` method in `DepositEntityOperations` and `DepositStore`
- Updated `SearchParser` to handle the new `REVERSAL_TOKEN` search parameter type
- Added a test case in `DepositStoreSearchTest` to verify filtering by reversal token
- Updated fake implementations to support the new parameter

### How to test?

1. Run the new test case in `DepositStoreSearchTest` that verifies filtering deposits by reversal token
2. Verify that deposits can be successfully filtered by a specific reversal token
3. Ensure that when a reversal token is provided, only deposits with matching reversal tokens are returned

### Why make this change?

This change enables more granular searching of deposits by allowing filtering based on reversal tokens. This is useful for tracking specific deposit reversals and improves the flexibility of the deposit search functionality.