### PR TITLE
do not cache errors after on-chain submission

### DIFF
--- a/common/src/main/kotlin/xyz/block/bittycity/common/idempotency/IdempotencyHandler.kt
+++ b/common/src/main/kotlin/xyz/block/bittycity/common/idempotency/IdempotencyHandler.kt
@@ -120,6 +120,22 @@ class IdempotencyHandler<ID, REQ>(
     }.bind()
   }
 
+  /**
+   * Deletes a cached response, allowing future retries with the same parameters.
+   * Used when error caching should be skipped (e.g., for post-submission withdrawal states).
+   *
+   * @param idempotencyKey The idempotency key.
+   * @param id The request identifier.
+   */
+  fun deleteCachedResponse(
+    idempotencyKey: String,
+    id: ID
+  ): Result<Unit> = result {
+    transactor.transact("Delete response") {
+      deleteResponse(idempotencyKey, id)
+    }.bind()
+  }
+
   private fun buildResponse(
     id: ID,
     idempotencyKey: String,

--- a/common/src/main/kotlin/xyz/block/bittycity/common/idempotency/IdempotencyOperations.kt
+++ b/common/src/main/kotlin/xyz/block/bittycity/common/idempotency/IdempotencyOperations.kt
@@ -22,6 +22,11 @@ interface IdempotencyOperations<ID, REQ> : Operations {
     idempotencyKey: String,
     response: IdempotentResponse<ID, REQ>
   ): Result<IdempotentResponse<ID, REQ>>
+
+  fun deleteResponse(
+    idempotencyKey: String,
+    requestId: ID
+  ): Result<Unit>
 }
 
 sealed class IdempotencyStoreError(message: String) :

--- a/innie/src/test/kotlin/xyz/block/bittycity/innie/testing/FakeResponseOperations.kt
+++ b/innie/src/test/kotlin/xyz/block/bittycity/innie/testing/FakeResponseOperations.kt
@@ -51,6 +51,14 @@ class FakeResponseOperations : ResponseOperations {
     updated
   }
 
+  override fun deleteResponse(
+    idempotencyKey: String,
+    requestId: DepositToken
+  ): Result<Unit> = result {
+    val key = idempotencyKey to requestId
+    responses.remove(key)
+  }
+
   fun clear() {
     responses.clear()
   }

--- a/outie/src/main/kotlin/xyz/block/bittycity/outie/api/OnChainWithdrawalDomainApi.kt
+++ b/outie/src/main/kotlin/xyz/block/bittycity/outie/api/OnChainWithdrawalDomainApi.kt
@@ -24,6 +24,8 @@ import xyz.block.bittycity.outie.controllers.DomainController
 import xyz.block.bittycity.outie.controllers.IdempotencyHandler
 import xyz.block.bittycity.outie.models.CollectingInfo
 import xyz.block.bittycity.outie.models.RequirementId
+import xyz.block.bittycity.outie.models.WaitingForConfirmedOnChainStatus
+import xyz.block.bittycity.outie.models.WaitingForPendingConfirmationStatus
 import xyz.block.bittycity.outie.models.Withdrawal
 import xyz.block.bittycity.outie.models.WithdrawalState
 import xyz.block.bittycity.outie.models.WithdrawalToken
@@ -136,8 +138,12 @@ class OnChainWithdrawalDomainApi @Inject constructor(
         hurdleGroupId
       )
 
-      // Errors at the API level are never retryable for withdrawals so we can save error responses
-      idempotencyHandler.updateCachedResponse(hash, id, result).bind()
+      // For post-submission states, skip error caching to allow retries to discover real outcome.
+      // Successes are always cached regardless of state.
+      val shouldCacheError = withdrawal.state !in NON_CACHEABLE_ERROR_STATES
+      if (result.isSuccess || shouldCacheError) {
+        idempotencyHandler.updateCachedResponse(hash, id, result).bind()
+      }
       result.bind()
     }
   }
@@ -223,8 +229,12 @@ class OnChainWithdrawalDomainApi @Inject constructor(
         Operation.RESUME
       )
 
-      // Errors at the API level are never retryable for withdrawals so we can save error responses
-      idempotencyHandler.updateCachedResponse(hash, id, result).bind()
+      // For post-submission states, skip error caching to allow retries to discover real outcome.
+      // Successes are always cached regardless of state.
+      val shouldCacheError = withdrawal.state !in NON_CACHEABLE_ERROR_STATES
+      if (result.isSuccess || shouldCacheError) {
+        idempotencyHandler.updateCachedResponse(hash, id, result).bind()
+      }
       result.bind()
     }
   }
@@ -289,6 +299,17 @@ class OnChainWithdrawalDomainApi @Inject constructor(
         ?: raise(InvalidSourceBalanceToken(customerId, providedSourceBalanceToken))
     } ?: customerSourceBalanceTokens.firstOrNull()?.balanceId ?: raise(
       InvalidSourceBalanceToken(customerId, BalanceId("No default balance token found"))
+    )
+  }
+
+  companion object {
+    /**
+     * States where bitcoin has been submitted on-chain and error caching should be skipped.
+     * Transient errors in these states should allow retries to discover the real outcome.
+     */
+    private val NON_CACHEABLE_ERROR_STATES = setOf(
+      WaitingForPendingConfirmationStatus,
+      WaitingForConfirmedOnChainStatus,
     )
   }
 }

--- a/outie/src/main/kotlin/xyz/block/bittycity/outie/api/OnChainWithdrawalDomainApi.kt
+++ b/outie/src/main/kotlin/xyz/block/bittycity/outie/api/OnChainWithdrawalDomainApi.kt
@@ -143,6 +143,9 @@ class OnChainWithdrawalDomainApi @Inject constructor(
       val shouldCacheError = withdrawal.state !in NON_CACHEABLE_ERROR_STATES
       if (result.isSuccess || shouldCacheError) {
         idempotencyHandler.updateCachedResponse(hash, id, result).bind()
+      } else {
+        // Delete the incomplete idempotency row to allow retries
+        idempotencyHandler.deleteCachedResponse(hash, id).bind()
       }
       result.bind()
     }
@@ -234,6 +237,9 @@ class OnChainWithdrawalDomainApi @Inject constructor(
       val shouldCacheError = withdrawal.state !in NON_CACHEABLE_ERROR_STATES
       if (result.isSuccess || shouldCacheError) {
         idempotencyHandler.updateCachedResponse(hash, id, result).bind()
+      } else {
+        // Delete the incomplete idempotency row to allow retries
+        idempotencyHandler.deleteCachedResponse(hash, id).bind()
       }
       result.bind()
     }

--- a/outie/src/test/kotlin/xyz/block/bittycity/outie/api/OnChainWithdrawalDomainApiErrorCachingTest.kt
+++ b/outie/src/test/kotlin/xyz/block/bittycity/outie/api/OnChainWithdrawalDomainApiErrorCachingTest.kt
@@ -1,0 +1,172 @@
+package xyz.block.bittycity.outie.api
+
+import xyz.block.bittycity.common.idempotency.CachedError
+import xyz.block.bittycity.outie.models.HoldingSubmission
+import xyz.block.bittycity.outie.models.ObservedInMempool
+import xyz.block.bittycity.outie.models.RequirementId
+import xyz.block.bittycity.outie.models.WaitingForConfirmedOnChainStatus
+import xyz.block.bittycity.outie.models.WaitingForPendingConfirmationStatus
+import xyz.block.bittycity.outie.testing.Arbitrary
+import xyz.block.bittycity.outie.testing.BittyCityTestCase
+import io.kotest.matchers.result.shouldBeFailure
+import io.kotest.matchers.result.shouldBeSuccess
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.beInstanceOf
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.kotest.property.arbitrary.next
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Test
+import xyz.block.domainapi.Input
+
+/**
+ * Tests that verify error caching behavior for withdrawals in different states.
+ *
+ * Background: During a production incident, transient errors in post-submission states
+ * were cached, preventing retries and permanently blocking withdrawals. This test suite
+ * ensures that errors in post-submission states (where bitcoin has already been sent) are
+ * NOT cached, allowing retries to discover the real outcome.
+ */
+class OnChainWithdrawalDomainApiErrorCachingTest : BittyCityTestCase() {
+
+  @Inject
+  private lateinit var onChainWithdrawalDomainApi: OnChainWithdrawalDomainApi
+
+  @Test
+  fun `errors in WaitingForPendingConfirmationStatus are not cached`() = runTest {
+    // Create a withdrawal in WaitingForPendingConfirmationStatus state
+    val withdrawal = data.seedWithdrawal(
+      state = WaitingForPendingConfirmationStatus,
+      amount = Arbitrary.amount.next(),
+      walletAddress = Arbitrary.walletAddress.next(),
+    )
+
+    // Configure the limit client to fail, simulating a transient error
+    limitClient.failNextEvaluation()
+
+    // First call should fail due to the simulated error
+    val firstResult = onChainWithdrawalDomainApi.execute(
+      withdrawal.id,
+      emptyList<Input.HurdleResponse<RequirementId>>()
+    )
+    firstResult.shouldBeFailure()
+
+    // Second call with the same parameters should NOT return a cached error
+    // Instead, it should retry the operation
+    // To verify this, we ensure the limit client is called again (not failing this time)
+    limitClient.reset()
+
+    // If the error was cached, this would return CachedError immediately
+    // If NOT cached, it will retry and succeed (or fail differently)
+    val secondResult = onChainWithdrawalDomainApi.execute(
+      withdrawal.id,
+      emptyList<Input.HurdleResponse<RequirementId>>()
+    )
+
+    // The result should be a success or a different error, NOT a CachedError
+    // This proves the first error was not cached
+    secondResult.exceptionOrNull() shouldNot beInstanceOf<CachedError>()
+  }
+
+  @Test
+  fun `errors in WaitingForConfirmedOnChainStatus are not cached`() = runTest {
+    // Create a withdrawal in WaitingForConfirmedOnChainStatus state
+    val withdrawal = data.seedWithdrawal(
+      state = WaitingForConfirmedOnChainStatus,
+      amount = Arbitrary.amount.next(),
+      walletAddress = Arbitrary.walletAddress.next(),
+    )
+
+    // Configure the limit client to fail, simulating a transient error
+    limitClient.failNextEvaluation()
+
+    // First call should fail due to the simulated error
+    val firstResult = onChainWithdrawalDomainApi.execute(
+      withdrawal.id,
+      emptyList<Input.HurdleResponse<RequirementId>>()
+    )
+    firstResult.shouldBeFailure()
+
+    // Second call with the same parameters should NOT return a cached error
+    limitClient.reset()
+
+    val secondResult = onChainWithdrawalDomainApi.execute(
+      withdrawal.id,
+      emptyList<Input.HurdleResponse<RequirementId>>()
+    )
+
+    // Should not be a CachedError - the error should not have been cached
+    secondResult.exceptionOrNull() shouldNot beInstanceOf<CachedError>()
+  }
+
+  @Test
+  fun `errors in pre-submission states are cached`() = runTest {
+    // Create a withdrawal in HoldingSubmission state (pre-submission)
+    val withdrawal = data.seedWithdrawal(
+      state = HoldingSubmission,
+      amount = Arbitrary.amount.next(),
+      walletAddress = Arbitrary.walletAddress.next(),
+    )
+
+    // Configure the limit client to fail
+    limitClient.failNextEvaluation()
+
+    // First call should fail
+    val firstResult = onChainWithdrawalDomainApi.execute(
+      withdrawal.id,
+      emptyList<Input.HurdleResponse<RequirementId>>()
+    )
+    firstResult.shouldBeFailure()
+
+    // Reset the limit client so it would succeed on the next call
+    limitClient.reset()
+
+    // Second call should return the CACHED error, not retry
+    val secondResult = onChainWithdrawalDomainApi.execute(
+      withdrawal.id,
+      emptyList<Input.HurdleResponse<RequirementId>>()
+    )
+
+    // For pre-submission states, the error should be cached
+    // This means the second call returns a CachedError immediately
+    secondResult.shouldBeFailure()
+    secondResult.exceptionOrNull().shouldBeInstanceOf<CachedError>()
+  }
+
+  @Test
+  fun `successes in post-submission states are cached`() = runTest {
+    // Create a withdrawal in WaitingForPendingConfirmationStatus state
+    val withdrawal = data.seedWithdrawal(
+      state = WaitingForPendingConfirmationStatus,
+      amount = Arbitrary.amount.next(),
+      walletAddress = Arbitrary.walletAddress.next(),
+    )
+
+    val resumeResult = ObservedInMempool(
+      Arbitrary.stringToken.next(),
+      Arbitrary.outputIndex.next()
+    )
+
+    // First call should succeed
+    val firstResult = onChainWithdrawalDomainApi.resume(
+      withdrawal.id,
+      resumeResult
+    )
+    firstResult.shouldBeSuccess()
+
+    // Second call with same parameters should return cached success
+    val secondResult = onChainWithdrawalDomainApi.resume(
+      withdrawal.id,
+      resumeResult
+    )
+    secondResult.shouldBeSuccess()
+
+    // Verify it was actually cached by checking that the withdrawal state
+    // only transitioned once (not twice)
+    val finalWithdrawal = withdrawalWithToken(withdrawal.id)
+    finalWithdrawal.state shouldBe WaitingForConfirmedOnChainStatus
+  }
+
+}

--- a/outie/src/test/kotlin/xyz/block/bittycity/outie/testing/fakes/FakeResponseOperations.kt
+++ b/outie/src/test/kotlin/xyz/block/bittycity/outie/testing/fakes/FakeResponseOperations.kt
@@ -50,6 +50,14 @@ class FakeResponseOperations : ResponseOperations {
     updatedResponse
   }
 
+  override fun deleteResponse(
+    idempotencyKey: String,
+    requestId: WithdrawalToken
+  ): Result<Unit> = result {
+    val key = CompositeKey(idempotencyKey, requestId)
+    responses.remove(key)
+  }
+
   fun reset() {
     responses.clear()
   }


### PR DESCRIPTION
### Background
Once a bitcoin withdrawal is submitted on-chain, we need to know the outcome and communicate that properly downstream. This means, if we have transient errors/errors processing events afterwards, we should not cache the response as they likely require some type of re-drive/retry mechanism so we can honor what happened on-chain

### Changes made
1. For states following bitcoin on-chian submission, do not cache error responses

### Testing
Unit test