### PR TITLE
Prepare for release outie 0.2.2

### DIFF
--- a/outie/CHANGELOG.md
+++ b/outie/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [0.2.2]
+
+* Reduce Rush fee when balance is above minimum but below minimum + fee.
+* Do not cache errors after on-chain submission to allow retries to discover real outcome.
+
 ## [0.2.1]
 
 * Moved withdrawal eligibility client contract to common EligibilityClient.

--- a/outie/gradle.properties
+++ b/outie/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.2.1
+VERSION_NAME=0.2.2
 
 POM_ARTIFACT_ID=outie
 POM_NAME=Bitty City - Outie


### PR DESCRIPTION
## Summary
- Bump outie version to 0.2.2
- Update CHANGELOG with new features since 0.2.1

## Changes in this release
- Reduce Rush fee when balance is above minimum but below minimum + fee (#128)
- Do not cache errors after on-chain submission to allow retries to discover real outcome (#130)

## Test plan
- [x] Tests pass (`gradle :outie:test`)
- [x] Review changes
- [x] Merge PR
- [x] Tag release with `outie-v0.2.2`
- [x] Publish to Maven Central

🤖 Generated with [Claude Code](https://claude.com/claude-code)