### PR TITLE
[BCOIN-7252] Use zero fee for on-chain submission when fee was refunded

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,9 +5,13 @@ domainApi = "0.5.3"
 domainApiKfsm = "0.5.3"
 domainApiKfsmv2 = "0.1.0"
 guice = "7.0.0"
-jodaMoney = "2.0.3"
+# joda-money 2.x requires Java 21. This project targets Java 11 for
+# downstream consumer compatibility, so we stay on the 1.x line.
+jodaMoney = "1.0.7"
 kfsm = "0.12.0"
-kfsmv2 = "2.3.0"
+# kfsm-v2 2.2+ changed Outbox method signatures to return Result<…>.
+# Pinned to 2.1.0 until InMemoryOutbox and related code are updated to match.
+kfsmv2 = "2.1.0"
 kotest = "5.9.1"
 kotlinxCoroutines = "1.10.2"
 kotestArrow = "2.0.0"

--- a/outie/src/main/kotlin/xyz/block/bittycity/outie/client/OnChainClient.kt
+++ b/outie/src/main/kotlin/xyz/block/bittycity/outie/client/OnChainClient.kt
@@ -60,7 +60,10 @@ data class WithdrawRequest(
       val withdrawalAmount = amount ?: raise(IllegalArgumentException("Amount is required"))
       val selectedSpeed =
         selectedSpeed ?: raise(IllegalArgumentException("Selected speed is required"))
-      val withdrawalFee = selectedSpeed.totalFee
+      // If the customer fee has been refunded (e.g. while held for sanctions review), the on-chain
+      // submission must reflect a zero fee since the corresponding ledger entry has already been
+      // voided and reposted with a zero fee.
+      val withdrawalFee = if (feeRefunded) Bitcoins.ZERO else selectedSpeed.totalFee
 
       Result.catch {
         WithdrawRequest(

--- a/outie/src/test/kotlin/xyz/block/bittycity/outie/client/WithdrawRequestTest.kt
+++ b/outie/src/test/kotlin/xyz/block/bittycity/outie/client/WithdrawRequestTest.kt
@@ -87,7 +87,8 @@ class WithdrawRequestTest {
     targetWalletAddress: Address? = Arbitrary.walletAddress.next(),
     amount: Bitcoins? = Arbitrary.amount.next(),
     fee: Bitcoins = Arbitrary.fee.next(),
-    speed: WithdrawalSpeed = Arbitrary.speed.next()
+    speed: WithdrawalSpeed = Arbitrary.speed.next(),
+    feeRefunded: Boolean = false
   ) = Withdrawal(
     id = Arbitrary.withdrawalToken.next(),
     createdAt = Instant.now(),
@@ -106,7 +107,8 @@ class WithdrawRequestTest {
       serviceFee = FlatFee(Bitcoins(0)),
       approximateWaitTime = 1.minutes
     ),
-    exchangeRate = Arbitrary.exchangeRate.next()
+    exchangeRate = Arbitrary.exchangeRate.next(),
+    feeRefunded = feeRefunded
   )
 
   @Test
@@ -135,5 +137,25 @@ class WithdrawRequestTest {
     withdrawal.toWithdrawalRequest()
       .shouldBeFailure()
       .message shouldBe "Amount is required"
+  }
+
+  @Test
+  fun `fee is taken from selectedSpeed when feeRefunded is false`() {
+    val originalFee = Bitcoins(2724)
+    val withdrawal = createWithdrawal(fee = originalFee, feeRefunded = false)
+
+    val request = withdrawal.toWithdrawalRequest().getOrThrow()
+
+    request.fee shouldBe originalFee
+  }
+
+  @Test
+  fun `fee is zero when feeRefunded is true`() {
+    val originalFee = Bitcoins(2724)
+    val withdrawal = createWithdrawal(fee = originalFee, feeRefunded = true)
+
+    val request = withdrawal.toWithdrawalRequest().getOrThrow()
+
+    request.fee shouldBe Bitcoins.ZERO
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,19 @@
       "matchManagers": ["gradle"],
       "matchPackageNames": ["org.jetbrains.kotlin:.*"],
       "enabled": false
+    },
+    {
+      "description": "joda-money 2.x requires Java 21; this project targets Java 11 for downstream consumer compatibility. Stay on the 1.x line.",
+      "matchManagers": ["gradle", "gradle-version-catalog"],
+      "matchPackageNames": ["org.joda:joda-money"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": "kfsm-v2 2.2+ changed the Outbox interface to return Result<…>. Pinned until the test fakes (InMemoryOutbox) and related code are updated to match.",
+      "matchManagers": ["gradle", "gradle-version-catalog"],
+      "matchPackageNames": ["app.cash.kfsm:kfsm-v2"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Why

When a withdrawal is held for sanctions review, `SanctionsHold` calls `ledgerClient.refundFee(...)`, which voids the original ledger entry and reposts it with a zero fee, and sets `withdrawal.feeRefunded = true`.

However the on-chain submission path still read the original `selectedSpeed.totalFee` when constructing the `WithdrawRequest`. As a result, the on-chain gateway received a stale non-zero customer fee while the corresponding ledger entry was already $0 — inconsistent state between our ledger and the gateway.

## What

`Withdrawal.toWithdrawalRequest()` (in `OnChainClient.kt`) now uses `Bitcoins.ZERO` as the on-chain fee when `feeRefunded == true`, otherwise it continues to use `selectedSpeed.totalFee`.

This keeps the on-chain submission consistent with the ledger entry that was already adjusted to zero during the sanctions-hold refund.

## Tests

Added two unit tests in `WithdrawRequestTest`:

- `fee is taken from selectedSpeed when feeRefunded is false` — regression coverage for the normal path.
- `fee is zero when feeRefunded is true` — covers the bug fix.

## Drive-by: unbreak CI

`main` has been red since 2026-04-23 (PR #91 — Renovate "Update all non-major dependencies") due to two unrelated dependency bumps that pulled in incompatible upstream changes:

### 1. `joda-money` 1.0.7 → 2.0.3

joda-money 2.0 is explicitly built for Java 21+, while this project targets Java 11 for downstream consumer compatibility. The Java 11 test JVM throws `UnsupportedClassVersionError` for `CurrencyUnit`, cascading into `NoClassDefFoundError` for `Bitcoins` and breaking every test that touches money.

Fix:

1. Pin `jodaMoney` back to `1.0.7` with an inline comment explaining the Java 11 constraint.
2. Add a Renovate rule blocking **major** version updates for `org.joda:joda-money` (patch/minor updates on the 1.x line are still allowed).

### 2. `kfsm-v2` 2.1.0 → 2.3.0

kfsm-v2 2.2+ changed the `Outbox` interface so every method returns `Result<…>` instead of a bare value. `InMemoryOutbox` in `innie`'s tests still implements the old signatures, so `:innie:compileTestKotlin` fails to compile.

Fix:

1. Pin `kfsmv2` back to `2.1.0` with an inline comment.
2. Add a Renovate rule disabling further `app.cash.kfsm:kfsm-v2` updates until `InMemoryOutbox` (and any related code) is updated to the new `Result<…>` contract.